### PR TITLE
#7 Add forgotten stringify in 2 requests

### DIFF
--- a/src/components/HeaderIdig.vue
+++ b/src/components/HeaderIdig.vue
@@ -177,10 +177,10 @@ export default {
               username: this.username,
               password: this.password,
             },
-            data: {
+            data: JSON.stringify({
               head: "",
               surveys: [],
-            },
+            }),
           })
             .then((response) => {
               // stores  prefences base64 in session storage to allow PUSH

--- a/src/components/OverLay.vue
+++ b/src/components/OverLay.vue
@@ -251,12 +251,12 @@ export default {
           username: localStorage.username,
           password: localStorage.password,
         },
-        data: {
+        data: JSON.stringify({
           head: JSON.parse(sessionStorage.trenchesVersion)[this.selectedTrench],
           device: "webapp",
           surveys: this.trenchtoUpdate,
           preferences: sessionStorage.preferences,
-        },
+        }),
       })
         .then(() => {
           // alert("connection valide");


### PR DESCRIPTION
Issue : https://github.com/esag-swiss/iDig-Webapp/issues/7

Description :
We had a bug, which appeared when switching to vite : without these `stringify`, the server returned an error 400.
I added it in one place in the commit https://github.com/esag-swiss/iDig-Webapp/commit/1138a71b19494cd4f3174060e1a0da668876f4a5 , but forgot to add it in 2 places. These was fixed here.
