### PR TITLE
Add auto pull after push 'saving'

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,7 +9,10 @@
       <!-- SIDEBAR -->
       <div class="p-1 col-md-2">
         <div class="sticky-top">
-          <TheControlTrenches @selected-trench="selectedTrench">
+          <TheControlTrenches
+            ref="controlTrenches"
+            @selected-trench="selectedTrench"
+          >
           </TheControlTrenches>
 
           <TheControlFields @check-fields="checkFields"> </TheControlFields>
@@ -97,6 +100,9 @@ export default {
     },
     checkFields(emited) {
       this.checkedFields = emited;
+    },
+    reload() {
+      this.$refs.controlTrenches.fetchAllTrenchesData();
     },
   },
 };

--- a/src/components/TheControlTrenches.vue
+++ b/src/components/TheControlTrenches.vue
@@ -118,8 +118,6 @@ export default {
         return object.Type.includes(newType);
       });
       this.setFilteredTrenchesItemsStore(tempItems);
-
-      console.log(tempItems);
     },
   },
 
@@ -178,6 +176,7 @@ export default {
     },
 
     fetchAllTrenchesData: function () {
+      // also used to reload after saving from TheItem
       let itemsToEmit = [];
       let itemsToEmitStore = [];
 

--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -152,6 +152,7 @@ export default defineComponent({
   methods: {
     clearTheItem() {
       this.currentItem = false;
+      this.$parent.reload();
     },
   },
 });


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/63`

**Description** :    
This PR enable auto pull trenches from iDig-server after a push because when user were closing the form TheItem after saving a change (= push) he was still seeing data from previous pull that was not uptodate