### PR TITLE
Make language selection persistent

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -34,10 +34,9 @@
           @input="(event) => setPassword(event.target.value)"
         />
         <select
-          :value="'fr'"
-          type="selectedType"
+          :value="lang"
           class="m-2 text-light input-header-small"
-          @change="(event) => setLang(event.target.value)"
+          @change="(event) => changeLang(event.target.value)"
         >
           <option>fr</option>
           <option>en</option>
@@ -59,7 +58,10 @@
   </nav>
 </template>
 <script>
-import { storePersistentUserSettings } from "@/services/PersistentUserSettings";
+import {
+  storePersistentUserConnection,
+  storePersistentUserLang,
+} from "@/services/PersistentUserSettings";
 import { mapActions, mapState } from "pinia";
 import { useAppStore } from "@/stores/app";
 import { useDataStore } from "@/stores/data";
@@ -72,6 +74,7 @@ export default {
       "username",
       "password",
       "isLoaded",
+      "lang",
     ]),
     ...mapState(useDataStore, ["firstTrench"]),
   },
@@ -94,6 +97,10 @@ export default {
       "fetchProjectTrenchesNames",
       "fetchProjectTrenchesNamesFromFile",
     ]),
+    changeLang(lang) {
+      this.setLang(lang);
+      storePersistentUserLang();
+    },
     async connect() {
       this.setServer(this.cleanServerUserEntry(this.server));
 
@@ -104,7 +111,7 @@ export default {
         try {
           await this.fetchProjectTrenchesNames();
           await this.fetchPreferences(this.firstTrench);
-          storePersistentUserSettings();
+          storePersistentUserConnection();
         } catch (e) {
           /* empty */
         }
@@ -114,7 +121,7 @@ export default {
         try {
           this.fetchProjectTrenchesNamesFromFile();
           await this.fetchPreferences(this.firstTrench);
-          storePersistentUserSettings();
+          storePersistentUserConnection();
         } catch (e) {
           /* empty */
         }

--- a/src/services/PersistentUserSettings.js
+++ b/src/services/PersistentUserSettings.js
@@ -1,10 +1,14 @@
 import { useAppStore } from "@/stores/app";
 
-export function storePersistentUserSettings() {
+export function storePersistentUserConnection() {
   const { server, project, username, password } = useAppStore();
-
   localStorage.setItem("server", server);
   localStorage.setItem("project", project);
   localStorage.setItem("username", username);
   localStorage.setItem("password", password);
+}
+
+export function storePersistentUserLang() {
+  const { lang } = useAppStore();
+  localStorage.setItem("lang", lang);
 }

--- a/src/stores/app.js
+++ b/src/stores/app.js
@@ -3,7 +3,7 @@ import { defineStore } from "pinia";
 export const useAppStore = defineStore("app", {
   state: () => ({
     loadingCount: 0,
-    lang: "fr",
+    lang: localStorage.lang ?? "fr",
     isLoaded: false,
     // Load local storage values for these elements, or empty string if not exist :
     username: localStorage.username ?? "",


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/96`

**Description** :    
By default, french language is used, and if the user change it, it is saved in local storage, and used when reloading
