### PR TITLE
Make the header non-editable when connected, and allow disconnection

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -6,7 +6,21 @@
         <!-- Title -->
         <div class="navbar-brand" href="#">iDig webapp</div>
       </ul>
-      <form class="form-inline my-0">
+
+      <div v-if="isLoaded">
+        <span class="text-white">
+          {{ project }} - {{ username }}@{{ server }}
+        </span>
+        <button
+          type="button"
+          class="btn btn-outline-secondary m-2 px-1 py-0"
+          @click="resetStores"
+        >
+          déconnexion
+        </button>
+      </div>
+
+      <form v-else class="form-inline my-0">
         <div class="navbar-text text-light p-2">server:</div>
         <input
           :value="server"
@@ -47,8 +61,7 @@
 
         <button
           type="button"
-          class="btn btn-outline-secondary m-2 px-1 py-0"
-          :class="{ 'is-loaded': isLoaded }"
+          class="connexion btn btn-outline-secondary m-2 px-1 py-0"
           @click="connect()"
         >
           connexion
@@ -97,6 +110,12 @@ export default {
       "fetchProjectTrenchesNames",
       "fetchProjectTrenchesNamesFromFile",
     ]),
+    resetStores() {
+      const dataStore = useDataStore();
+      dataStore.$reset();
+      const appStore = useAppStore();
+      appStore.$reset();
+    },
     changeLang(lang) {
       this.setLang(lang);
       storePersistentUserLang();
@@ -136,7 +155,7 @@ export default {
 };
 </script>
 <style>
-.is-loaded {
+.connexion {
   color: #fff;
   background-color: #26a69a;
   border-color: #26a69a;

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -11,6 +11,7 @@
         <span class="text-white">
           {{ project }} - {{ username }}@{{ server }}
         </span>
+        <TheHeaderLang />
         <button
           type="button"
           class="btn btn-outline-secondary m-2 px-1 py-0"
@@ -47,17 +48,7 @@
           placeholder="Password"
           @input="(event) => setPassword(event.target.value)"
         />
-        <select
-          :value="lang"
-          class="m-2 text-light input-header-small"
-          @change="(event) => changeLang(event.target.value)"
-        >
-          <option>fr</option>
-          <option>en</option>
-          <option>el</option>
-          <option>it</option>
-          <option>de</option>
-        </select>
+        <TheHeaderLang />
 
         <button
           type="button"
@@ -71,15 +62,14 @@
   </nav>
 </template>
 <script>
-import {
-  storePersistentUserConnection,
-  storePersistentUserLang,
-} from "@/services/PersistentUserSettings";
+import { storePersistentUserConnection } from "@/services/PersistentUserSettings";
 import { mapActions, mapState } from "pinia";
 import { useAppStore } from "@/stores/app";
 import { useDataStore } from "@/stores/data";
+import TheHeaderLang from "@/components/TheHeaderLang.vue";
 
 export default {
+  components: { TheHeaderLang },
   computed: {
     ...mapState(useAppStore, [
       "server",
@@ -87,7 +77,6 @@ export default {
       "username",
       "password",
       "isLoaded",
-      "lang",
     ]),
     ...mapState(useDataStore, ["firstTrench"]),
   },
@@ -98,7 +87,6 @@ export default {
       "setProject",
       "setUsername",
       "setPassword",
-      "setLang",
     ]),
     ...mapActions(useDataStore, [
       "setProjectTrenchesNames",
@@ -115,10 +103,6 @@ export default {
       dataStore.$reset();
       const appStore = useAppStore();
       appStore.$reset();
-    },
-    changeLang(lang) {
-      this.setLang(lang);
-      storePersistentUserLang();
     },
     async connect() {
       this.setServer(this.cleanServerUserEntry(this.server));

--- a/src/components/TheHeaderLang.vue
+++ b/src/components/TheHeaderLang.vue
@@ -1,0 +1,39 @@
+<template>
+  <select
+    :value="lang"
+    class="m-2 text-light input-header-small"
+    @change="(event) => changeLang(event.target.value)"
+  >
+    <option>fr</option>
+    <option>en</option>
+    <option>el</option>
+    <option>it</option>
+    <option>de</option>
+  </select>
+</template>
+<script>
+import { storePersistentUserLang } from "@/services/PersistentUserSettings";
+import { mapActions, mapState } from "pinia";
+import { useAppStore } from "@/stores/app";
+
+export default {
+  name: "TheHeaderLang",
+  computed: {
+    ...mapState(useAppStore, ["lang"]),
+  },
+  methods: {
+    ...mapActions(useAppStore, ["setLang"]),
+    changeLang(lang) {
+      this.setLang(lang);
+      storePersistentUserLang();
+    },
+  },
+};
+</script>
+<style>
+.input-header-small {
+  background: #212529;
+  border: 0px;
+  width: 3em;
+}
+</style>


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/100`

**Description** :    
- Make the header non-editable when connected, 
- Allow disconnection. For this, use the reset function of the stores. We also reset the app store, actually only for the isLoaded status, but it doesn't hurt to reset the connection details etc to the persistent localStorage settings
