### PR TITLE
Add all trenches API

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -95,7 +95,7 @@ export default {
       "setProjectPreferencesFields",
       "setProjectPreferencesBase64",
       "fetchPreferences",
-      "fetchProjectTrenchesNames",
+      "fetchIdigTrenchesNames",
       "fetchProjectTrenchesNamesFromFile",
     ]),
     resetStores() {
@@ -106,21 +106,11 @@ export default {
     },
     async connect() {
       this.setServer(this.cleanServerUserEntry(this.server));
-
-      // const devMode = "new_server";
-      const devMode = "old_server";
-
-      if (devMode === "new_server") {
-        try {
-          await this.fetchProjectTrenchesNames();
-          await this.fetchPreferences(this.firstTrench);
-          lsStoreConnection();
-        } catch (e) {
-          /* empty */
-        }
-      }
-
-      if (devMode === "old_server") {
+      try {
+        await this.fetchIdigTrenchesNames();
+        await this.fetchPreferences(this.firstTrench);
+        lsStoreConnection();
+      } catch (e) {
         try {
           this.fetchProjectTrenchesNamesFromFile();
           await this.fetchPreferences(this.firstTrench);

--- a/src/services/ApiClient.js
+++ b/src/services/ApiClient.js
@@ -38,6 +38,32 @@ export function apiFetchProjectTrenchesNames() {
     })
     .finally(() => decrementLoadingCount());
 }
+export function apiFetchIdigTrenchesNames() {
+  const {
+    server,
+    username,
+    password,
+    incrementLoadingCount,
+    decrementLoadingCount,
+  } = useAppStore();
+
+  incrementLoadingCount();
+  return axios({
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,PUT,POST,DELETE,PATCH,OPTIONS",
+    },
+    method: "get",
+    url: `${server}/idig/`,
+    auth: { username, password },
+  })
+    .catch((error) => {
+      displayError(error);
+      throw error;
+    })
+    .finally(() => decrementLoadingCount());
+}
 export function apiFetchTrenchVersion(trench) {
   const {
     server,

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import {
   apiFetchPreferences,
   apiFetchProjectTrenchesNames,
+  apiFetchIdigTrenchesNames,
   apiFetchSurvey,
   apiFetchTrenchVersion,
 } from "@/services/ApiClient";
@@ -51,7 +52,7 @@ export const useDataStore = defineStore("data", {
     },
 
     firstTrench(state) {
-      return state.projectTrenchesNames?.[0];
+      return state.projectTrenchesNames?.reverse()[0];
     },
 
     checkedTrenchesItems(state) {
@@ -111,6 +112,15 @@ export const useDataStore = defineStore("data", {
     async fetchProjectTrenchesNames() {
       return apiFetchProjectTrenchesNames().then((response) => {
         this.setProjectTrenchesNames(response.data);
+      });
+    },
+
+    async fetchIdigTrenchesNames() {
+      return apiFetchIdigTrenchesNames().then((response) => {
+        const uniqueNames = [
+          ...new Set(response.data.trenches.map((trench) => trench.name)),
+        ];
+        this.setProjectTrenchesNames(uniqueNames);
       });
     },
 


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/121`

**Description** :    
La pull request a été créée pour intégrer la fonctionnalité permettant à la web application d'accéder à la liste de toutes les tranchées disponibles via la nouvelle route introduite dans la dernière version officielle du serveur iDig. 
- Ajout d'une nouvelle fonction apiFetchIdigTrenchesNames dans le code de l'API client.
- Suppression des modes "oldServer" "newServer"
- La liste des trenches dans le code est encore utilisée dans le cas où apiFetchIdigTrenchesNames ne fonctionne pas. Cela permet à la webapp d'être retro compatible.