### PR TITLE
Removes 'no .wld' bug

### DIFF
--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -98,7 +98,7 @@ export default {
     },
     async createMapsOverlays() {
       const promises = this.checkedTrenchesItemsPlans.map((obj) => {
-        if (obj.RelationAttachments) {
+        if (obj.RelationAttachments?.includes("\n\n")) {
           return this.createMapsOverlay(obj.RelationAttachments, obj.Trench);
         }
       });


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/125`

**Description** :    
This PR is a quick fix to allow trenches to be loaded even if they have plans with no WLD file attached