### PR TITLE
Managing type and subtype labels

### DIFF
--- a/src/components/TheControlFields.vue
+++ b/src/components/TheControlFields.vue
@@ -1,15 +1,14 @@
 <template>
   <!-- TYPES -->
   <div class="p-1 m-1 border-0">
-    <h3
-      title="filter table data and show only fields available for the selected type"
-    >
+    <h3>
       {{
         projectPreferencesFieldsWithTranslation["Type"]
           ? projectPreferencesFieldsWithTranslation["Type"]
           : "Type"
       }}
     </h3>
+    <q-tooltip class="bg-accent"> {{ $t("app.typeTip") }} </q-tooltip>
   </div>
   <!-- dropdown for types and sub-types -->
   <select
@@ -22,14 +21,19 @@
       :key="type"
       :value="type.subtype || type.type"
     >
-      {{ type.plurals?.[lang] ?? type.type }}
+      {{
+        type.subtype
+          ? type.plurals?.[lang] ?? type.subtype
+          : type.plurals?.[lang] ?? type.type
+      }}
     </option>
   </select>
 
   <!-- FIELDS -->
   <div class="p-1 m-1 border-0">
-    <h3 title="display only fields for the selected type">
-      {{ $t("app.fields") }}
+    <h3>
+      {{ $t("app.fields")
+      }}<q-tooltip class="bg-accent"> {{ $t("app.fieldTip") }} </q-tooltip>
     </h3>
     <!-- liste les groupes pour le type sélectionné -->
     <ul

--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -5,7 +5,10 @@
       class="sticky-top q-fixed bg-grey-1 q-px-sm full-width row items-center justify-between"
     >
       <div class="col text-uppercase text-h6">
-        {{ projectPreferencesTypesTranslation[selectedItem.Type] }}
+        {{
+          projectPreferencesTypesTranslation[selectedItem.Subtype] ??
+          projectPreferencesTypesTranslation[selectedItem.Type]
+        }}
         {{ selectedItem.Identifier }}
       </div>
 
@@ -362,7 +365,6 @@ export default {
   computed: {
     ...mapState(useDataStore, [
       "projectPreferencesTypes",
-      "projectPreferencesTypesForSelect",
       "projectPreferencesTypesTranslation",
       "projectPreferencesFields",
       "projectPreferencesBase64",

--- a/src/components/TheItemLink.vue
+++ b/src/components/TheItemLink.vue
@@ -63,8 +63,11 @@ export default {
         const item = filteredItems[0];
         return {
           chipText:
-            this.projectPreferencesTypesTranslation[item.Type] +
-            ": " +
+            (this.projectPreferencesTypesTranslation[item.Subtype] ??
+              this.projectPreferencesTypesTranslation[item.Type]) +
+            " " +
+            item.Identifier +
+            " : " +
             item.Title,
           fullItem: item,
         };

--- a/src/components/TheItemStandalone.vue
+++ b/src/components/TheItemStandalone.vue
@@ -3,7 +3,10 @@
     <!--header-->
     <div class="sticky-top bg-grey-5">
       <div class="text-uppercase text-h6 accordion p-2">
-        {{ projectPreferencesTypesTranslation[currentItem.Type] }}
+        {{
+          projectPreferencesTypesTranslation[currentItem.Subtype] ??
+          projectPreferencesTypesTranslation[currentItem.Type]
+        }}
         {{ currentItem.Identifier }}
       </div>
     </div>

--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -169,7 +169,10 @@ export default {
         return cell.getValue();
       }
       return this.checkedFieldNames.map((fieldName) => ({
-        title: this.projectPreferencesFieldsWithTranslation[fieldName],
+        title:
+          this.projectPreferencesFieldsWithTranslation?.[fieldName] ||
+          this.fieldsSchema?.[fieldName]?.labels?.[this.lang] ||
+          fieldName,
         headerFilter: "input",
         field: fieldName,
         headerMenu: headerMenu,
@@ -353,7 +356,7 @@ export default {
     },
 
     getColumnFormatter(fieldName) {
-      if (fieldName === "Type") {
+      if (fieldName === "Type" || fieldName === "Subtype") {
         return (cell, formatterParams, onRendered) => {
           const value = cell.getValue();
           return this.projectPreferencesTypesTranslation[value] ?? value;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -4,6 +4,8 @@
     "trenches": "Sektoren",
     "no data": "Keine Daten ausgewählt",
     "connect": "Zuerst verbinden",
-    "map": " Karte"
+    "map": " Karte",
+    "typeTip": "Daten filtern und nur Felder anzeigen, die für den ausgewählten Typ oder Untertyp verfügbar sind",
+    "fieldTip": "Verfügbare Felder für den ausgewählten Typ oder Untertyp"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,8 @@
     "trenches": "Sectors",
     "no data": " No data selected",
     "map": "map",
-    "connect": "Connect first"
+    "connect": "Connect first",
+    "typeTip": "filter data and show only fields available for the selected type or subtype",
+    "fieldTip": "fields available for the selected type or subtype"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,6 +4,8 @@
     "trenches": "Secteurs",
     "no data": "Pas de données sélectionnées",
     "connect": "Connectez-vous",
-    "map": " carte"
+    "map": " carte",
+    "typeTip": "filtrer les données et afficher uniquement les champs disponibles pour le type ou le sous-type sélectionné",
+    "fieldTip": "champs disponibles pour le type ou le sous-type sélectionné"
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -4,6 +4,8 @@
     "trenches": "Settori",
     "no data": "Nessun dato selezionato",
     "connect": "Connetti prima",
-    "map": "mappa"
+    "map": "mappa",
+    "typeTip": "filtrare i dati e mostrare solo i campi disponibili per il tipo o sottotipo selezionato",
+    "fieldTip": "campi disponibili per il tipo o sottotipo selezionato"
   }
 }

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -39,20 +39,6 @@ export const useDataStore = defineStore("data", {
   }),
 
   getters: {
-    projectPreferencesTypesForSelect(state) {
-      if (state.projectPreferencesTypes) {
-        const { lang } = useAppStore();
-        let options = state.projectPreferencesTypes.map((field) => {
-          return {
-            value: field.type,
-            label: field.labels[lang],
-            subtype: field.subtype,
-          };
-        });
-        return options;
-      }
-    },
-
     projectPreferencesTypesForOption(state) {
       if (state.projectPreferencesTypes) {
         const { lang } = useAppStore();
@@ -75,14 +61,13 @@ export const useDataStore = defineStore("data", {
         const { lang } = useAppStore();
         let options = {};
         state.projectPreferencesTypes.forEach((field) => {
-          options[field.type] = field.labels[lang];
-          // Si un subtype est défini, ajout de la traduction pour le subtype
           if (field.subtype) {
             options[field.subtype] =
               field.labels[lang] ?? options[field.subtype];
+          } else {
+            options[field.type] = field.labels[lang];
           }
         });
-
         return options;
       }
     },
@@ -92,14 +77,13 @@ export const useDataStore = defineStore("data", {
         const { lang } = useAppStore();
         let options = {};
         state.projectPreferencesTypes.forEach((field) => {
-          options[field.type] = field.plurals?.[lang];
-          // Si un subtype est défini, ajout de la traduction pour le subtype
           if (field.subtype) {
             options[field.subtype] =
               field.plurals?.[lang] ?? options[field.subtype];
+          } else {
+            options[field.type] = field.plurals?.[lang];
           }
         });
-
         return options;
       }
     },
@@ -120,11 +104,11 @@ export const useDataStore = defineStore("data", {
           translatedLabels[this.projectPreferencesFields.indexOf(field)];
       }
 
-      if (fieldsSchema.Subtype) {
-        //
-        const subtypeLabel = fieldsSchema.Subtype.labels?.[lang] ?? "Subtype";
-        langKeys = { ...langKeys, Subtype: subtypeLabel };
-      }
+      // if (fieldsSchema.Subtype) {
+      //   //
+      //   const subtypeLabel = fieldsSchema.Subtype.labels?.[lang] ?? "Subtype";
+      //   langKeys = { ...langKeys, Subtype: subtypeLabel };
+      // }
       const translationObj = {};
       state.projectPreferencesTypes.forEach((typeObj) => {
         if (typeObj.groups && Array.isArray(typeObj.groups)) {


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/194`

**Description** :    
This pull request introduces changes to improve handling of subtypes across various components, enhance tooltip functionality, and refine localization strings. The most significant updates include adding tooltips for better user guidance, improving subtype handling in type-related translations, and cleaning up unused code.

### UI Enhancements:
* Added tooltips to `TheControlFields.vue` for "Type" and "Fields" headers to provide user guidance on filtering and available fields. (`[[1]](diffhunk://#diff-c7cc4026f1b47c5425f8a5bfb1c6d178c75dbaa37967f491f5fef16eceebb43bL4-R11)`, `[[2]](diffhunk://#diff-c7cc4026f1b47c5425f8a5bfb1c6d178c75dbaa37967f491f5fef16eceebb43bL25-R36)`)
* Updated localization files (`de.json`, `en.json`, `fr.json`, `it.json`) to include translations for tooltips related to types and fields. (`[[1]](diffhunk://#diff-9042ef10135202efba162b728f5178dfbdaab9695d0daf1fc90238ef28dde325L7-R9)`, `[[2]](diffhunk://#diff-b1791c7a47875ce85f2f1e57ef6c25a9b993660f9bcc840d8f21daac6161b5a0L7-R9)`, `[[3]](diffhunk://#diff-1e07f3b7b1d7f0a69a02b8d8a719fb987586a178894847e1e6a0414d0d5f6663L7-R9)`, `[[4]](diffhunk://#diff-fc3953d680bce8200648c72e55d80de612540e4a6f0bd16d6259a8e4a917245bL7-R9)`)

### Subtype Handling:
* Improved subtype support in `TheItem.vue`, `TheItemLink.vue`, and `TheItemStandalone.vue` by prioritizing subtype translations over type translations where applicable. (`[[1]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL8-R11)`, `[[2]](diffhunk://#diff-26b5b5d1925d9266c847f68b5e78a673564dea84f96cbe68c2d5a2a8465ec736L66-R69)`, `[[3]](diffhunk://#diff-4807b9712ff5d513de2316294348ce4a4c4615fb59c08472ef8adb2de4e3fe1cL6-R9)`)
* Enhanced column formatting in `TheTable.vue` to handle both "Type" and "Subtype" fields. (`[src/components/TheTable.vueL356-R359](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aL356-R359)`)

### Code Cleanup:
* Removed unused `projectPreferencesTypesForSelect` getter from `data.js` and streamlined logic for handling type and subtype translations. (`[[1]](diffhunk://#diff-2db3f92e6ede07c64fb87d02cafbf7ef9fb8f3302f340d7e57838d8e0330eb3bL42-L55)`, `[[2]](diffhunk://#diff-2db3f92e6ede07c64fb87d02cafbf7ef9fb8f3302f340d7e57838d8e0330eb3bL78-L85)`, `[[3]](diffhunk://#diff-2db3f92e6ede07c64fb87d02cafbf7ef9fb8f3302f340d7e57838d8e0330eb3bL95-L102)`)
* Commented out subtype-specific schema handling in `data.js` to simplify the codebase. (`[src/stores/data.jsL123-R111](diffhunk://#diff-2db3f92e6ede07c64fb87d02cafbf7ef9fb8f3302f340d7e57838d8e0330eb3bL123-R111)`)