### PR TITLE
Add SVG export

### DIFF
--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -26,7 +26,7 @@ import {
   baseLayersTree,
 } from "@/services/mapOverlays.js";
 import { loadItemsLayer } from "@/services/mapItemsLayers.js";
-import { exportMapAsPNG } from "@/services/mapExport.js";
+import { exportMapAsCompositeSVG } from "@/services/mapExport.js";
 import CustomLayersTree from "@/services/CustomLayersTree.js";
 
 export default {
@@ -134,7 +134,7 @@ export default {
     },
 
     exportMapAsPNG() {
-      exportMapAsPNG(this.map);
+      exportMapAsCompositeSVG(this.map);
     },
   },
 };

--- a/src/services/mapExport.js
+++ b/src/services/mapExport.js
@@ -16,10 +16,63 @@ export function exportMapAsPNG() {
     async: true,
   }).then((canvas) => {
     const imgData = canvas.toDataURL("image/png");
-    // Crée un lien de téléchargement
     const link = document.createElement("a");
     link.href = imgData;
     link.download = "map_export.png";
     link.click();
   });
+}
+
+export async function exportMapAsCompositeSVG() {
+  const mapElement = document.getElementById("mapContainer");
+  const svgLayer = document.querySelector(
+    "#mapContainer .leaflet-overlay-pane svg"
+  );
+  if (!mapElement || !svgLayer) {
+    alert("Impossible de trouver le fond raster ou la couche SVG.");
+    return;
+  }
+
+  // 1. Capture le raster en PNG (base64)
+  const canvas = await html2canvas(mapElement, {
+    ignoreElements: function (element) {
+      // Ignore les overlays SVG et les contrôles
+      if (
+        element.classList.contains("leaflet-control-zoom") ||
+        element.classList.contains("leaflet-top") ||
+        element.tagName === "svg"
+      ) {
+        return true;
+      }
+    },
+    useCORS: true,
+    async: true,
+  });
+  const imgData = canvas.toDataURL("image/png");
+
+  // 2. Prépare le SVG vectoriel
+  const svgClone = svgLayer.cloneNode(true);
+  // Récupère la taille du conteneur
+  const width = mapElement.offsetWidth;
+  const height = mapElement.offsetHeight;
+
+  // 3. Crée un SVG composite
+  const serializer = new XMLSerializer();
+  const svgContent = serializer.serializeToString(svgClone);
+  // Reconstruis le SVG pour Illustrator en ajoutant le namespace xlink et en passant à xlink:href
+  const compositeSVG = `<?xml version="1.0" encoding="UTF-8"?>
+  <svg xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+    <image xlink:href="${imgData}" x="0" y="0" width="${width}" height="${height}"/>
+    ${svgContent}
+  </svg>`;
+  // 4. Télécharge le SVG composite
+  const blob = new Blob([compositeSVG], { type: "image/svg+xml" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "map_composite_export.svg";
+  link.click();
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/199`

**Description** :    
This pull request replaces the map export functionality from PNG to a composite SVG format, enhancing the export process by combining raster and vector layers into a single file. The most significant changes include updating the method used in `TheMap.vue` and introducing the new `exportMapAsCompositeSVG` function in `mapExport.js`.

### Changes to map export functionality:

* [`src/components/TheMap.vue`](diffhunk://#diff-28a371e2358df5105b6a36bc3d6e9b46f5877ad9142c98abc911ca49be2df6a7L29-R29): Updated the import statement to use `exportMapAsCompositeSVG` instead of `exportMapAsPNG`. Modified the `exportMapAsPNG` method to call `exportMapAsCompositeSVG` for exporting the map. [[1]](diffhunk://#diff-28a371e2358df5105b6a36bc3d6e9b46f5877ad9142c98abc911ca49be2df6a7L29-R29) [[2]](diffhunk://#diff-28a371e2358df5105b6a36bc3d6e9b46f5877ad9142c98abc911ca49be2df6a7L137-R137)
* [`src/services/mapExport.js`](diffhunk://#diff-f56fd23bf75e59dc1e698f9cacbbc0a243d034140cbae5eff943289435eb0ccdL19-R78): Added a new `exportMapAsCompositeSVG` function to export maps as composite SVGs. This function captures raster layers as PNG, combines them with vector layers, and generates a downloadable SVG file.
