### PR TITLE
Feed TheMap with Tabulator data

### DIFF
--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -53,7 +53,12 @@ export default {
       "checkedTrenchesItemsPlans",
       "checkedTrenchesItemsSelectedTypeAndSearched",
       "projectPreferencesCRS",
+      "tableFilteredCheckedTrenchesItems",
     ]),
+    itemsForMap() {
+      return this.tableFilteredCheckedTrenchesItems ??
+        this.checkedTrenchesItemsSelectedTypeAndSearched;
+    },
   },
   watch: {
     // initialize map when first toggled on
@@ -69,8 +74,8 @@ export default {
         this.loadItemsLayer();
       }
     },
-    // reload items layer when removing trenches
-    checkedTrenchesItemsSelectedTypeAndSearched: function () {
+    // reload items layer when removing trenches or when table pushes filtered data
+    itemsForMap: function () {
       if (this.loadingCount === 0 && this.map) {
         this.loadItemsLayer();
       }
@@ -126,10 +131,11 @@ export default {
     },
 
     loadItemsLayer() {
+      // Prefer Tabulator visible data when available (set by TheTable.vue)
       this.itemsLayer = loadItemsLayer(
         this.map,
         this.itemsLayer, // Passe l'ancien layer pour suppression
-        this.checkedTrenchesItemsSelectedTypeAndSearched
+        this.itemsForMap
       );
     },
 

--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -265,9 +265,33 @@ export default {
         this.setIsItemSelected(true);
       }
     });
+
+    // When Tabulator filters change, push the currently displayed rows
+    // to the store so other components (map, exports...) can react.
+    this.tabulator.on("dataFiltered", (filters, rows) => {
+      // Use the `rows` argument from Tabulator's event — it's the
+      // list of RowComponent objects that match the active filters.
+      // Mapping `rows` -> row.getData() is more reliable than
+      // `getData(true)` which can return unexpected results
+      // depending on Tabulator version/timing.
+      let activeData = null;
+      if (rows && rows.length) {
+        try {
+          activeData = rows.map((r) => r.getData());
+        } catch (e) {
+          activeData = null;
+        }
+      }
+
+      if (!filters || filters.length === 0) {
+        this.setTableFilteredCheckedTrenchesItems(null);
+      } else {
+        this.setTableFilteredCheckedTrenchesItems(activeData);
+      }
+    });
   },
   methods: {
-    ...mapActions(useDataStore, ["setSyncPatches", "setSelectedItem"]),
+    ...mapActions(useDataStore, ["setSyncPatches", "setSelectedItem", "setTableFilteredCheckedTrenchesItems"]),
     ...mapActions(useAppStore, ["setIsItemSelected"]),
     clearTheItem() {
       this.setSelectedItem(null);
@@ -348,7 +372,7 @@ export default {
 
     getColumnFormatter(fieldName) {
       if (fieldName === "Type" || fieldName === "Subtype") {
-        return (cell, formatterParams, onRendered) => {
+        return (cell) => {
           const value = cell.getValue();
           return this.projectPreferencesTypesTranslation[value] ?? value;
         };
@@ -364,11 +388,7 @@ export default {
         fieldName === "DateLatest" ||
         fieldName === "Date"
       ) {
-        var formatterParams = {
-          outputFormat: "DD/MM/YYYY",
-          invalidPlaceholder: "(invalid date)",
-        };
-        return (cell, formatterParams, onRendered) => {
+        return (cell) => {
           const value = cell.getValue();
           // Exemple de formatage pour une date
           return new Date(value).toLocaleDateString();

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -36,6 +36,9 @@ export const useDataStore = defineStore("data", {
     selectedType: "Artifact",
     selectedItem: null,
     checkedFieldNames: [],
+    // Holds the subset of items currently visible in the Tabulator table
+    // (set by TheTable component when the user applies client-side filters)
+    tableFilteredCheckedTrenchesItems: null,
   }),
 
   getters: {
@@ -237,7 +240,7 @@ export const useDataStore = defineStore("data", {
         } // Si la propriété n'existe pas, retourner un tableau vide
 
         return items.filter((item) => {
-          if (!item.hasOwnProperty(propertyName)) {
+          if (!Object.prototype.hasOwnProperty.call(item, propertyName)) {
             return false;
           }
           const value = String(item[propertyName]);
@@ -442,7 +445,8 @@ export const useDataStore = defineStore("data", {
     trenchtoSync(trenchName) {
       return this.checkedTrenchesData[trenchName].map((obj) => {
         // remove property "Trench" before pushing data. It was added temporarly for helping webapp identifying items
-        const { Trench, ...newObj } = obj;
+        const newObj = Object.assign({}, obj);
+        delete newObj.Trench;
         return newObj;
       });
     },
@@ -489,6 +493,10 @@ export const useDataStore = defineStore("data", {
 
     setSearchText(searchText) {
       this.searchText = searchText;
+    },
+
+    setTableFilteredCheckedTrenchesItems(items) {
+      this.tableFilteredCheckedTrenchesItems = items;
     },
 
     setSyncPatches(syncPatches) {


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/206`

**Description** :    
This pull request improves the coordination between the data table and the map by ensuring that only the currently filtered and visible items in the table are displayed on the map. It introduces a new store property to hold the filtered items, updates the map to use this data, and refines some code for reliability and maintainability.

**Synchronization between Table Filters and Map Display:**

* Added a new property `tableFilteredCheckedTrenchesItems` to the data store to hold the subset of items currently visible in the Tabulator table after client-side filtering.
* Updated `TheTable.vue` to listen for Tabulator's `dataFiltered` event and push the filtered rows to the store via a new action, allowing other components (like the map) to react to changes in the table's visible data. [[1]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aR268-R294) [[2]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aR268-R294) [[3]](diffhunk://#diff-2db3f92e6ede07c64fb87d02cafbf7ef9fb8f3302f340d7e57838d8e0330eb3bR498-R501)

**Map Component Updates:**

* Modified `TheMap.vue` to prefer `tableFilteredCheckedTrenchesItems` for map display when available, falling back to the previous selection logic otherwise. The map layer is now reloaded whenever the filtered items change. [[1]](diffhunk://#diff-28a371e2358df5105b6a36bc3d6e9b46f5877ad9142c98abc911ca49be2df6a7R56-R61) [[2]](diffhunk://#diff-28a371e2358df5105b6a36bc3d6e9b46f5877ad9142c98abc911ca49be2df6a7L72-R78) [[3]](diffhunk://#diff-28a371e2358df5105b6a36bc3d6e9b46f5877ad9142c98abc911ca49be2df6a7R134-R138)

**Code Reliability and Maintenance:**

* Improved property existence checking in the data store by using `Object.prototype.hasOwnProperty.call` for safer property checks.
* Refactored object property removal in the `trenchtoSync` method for better clarity and reliability.
* Simplified and clarified cell formatter functions in `TheTable.vue` for type and date columns. [[1]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aL351-R375) [[2]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aL367-R391)