### PR TITLE
feat(table): add field group selection and filtered items counter

### DIFF
--- a/src/components/TheControlFields.vue
+++ b/src/components/TheControlFields.vue
@@ -36,35 +36,30 @@
       }}<q-tooltip class="bg-accent"> {{ $t("app.fieldTip") }} </q-tooltip>
     </h3>
     <!-- liste les groupes pour le type sélectionné -->
-    <ul
+    <BaseAccordion
       v-for="(group, index) in groupOfFieldsAccordingToTypeAndSubtype"
-      :key="group"
-      class="list-group"
+      :key="group.group"
+      :initial-open="index === 0"
+      :toggle-aria-label="
+        $t('app.toggle_group', { name: group.labels?.[lang] ?? group.group })
+      "
     >
-      <li
-        class="list-group-item accordion text-bold"
-        @click="isDisplayedArray[index] = !isDisplayedArray[index]"
-      >
-        {{ group.labels?.[lang] ?? group.group }}
-      </li>
-
-      <!-- liste les champs pour chaque groupe -->
-      <div v-if="isDisplayedArray[index]">
+      <template #title>
+        <BaseCheckbox
+          class="text-bold"
+          :model-value="isGroupAllChecked(group)"
+          :label="group.labels?.[lang] ?? group.group"
+          @update:model-value="checkFieldGroup(group)"
+        />
+      </template>
+      <template #content>
         <div v-for="(field, i) in group.fields" :key="i" class="m-0">
-          <input
-            v-model="checkedFieldNames"
-            :value="field.field"
-            type="checkbox"
+          <BaseCheckbox
+            :model-value="checkedFieldNames.includes(field.field)"
+            :label="fieldLabel(field)"
+            @update:model-value="(checked) => toggleField(field.field, checked)"
           />
-          <label class="pl-1 m-0" for="checkbox">
-            {{
-              // labels from types.groups.fields.labels.[lang] except if empty
-              field.labels?.[lang] ||
-              projectPreferencesFieldsWithTranslation?.[field.field] ||
-              fieldsSchema?.[field.field]?.labels?.[lang] ||
-              field.field
-            }}</label
-          ><q-toggle
+          <q-toggle
             v-if="field.field === 'RightsStatus'"
             v-model="hideArchived"
             :size="'sm'"
@@ -75,8 +70,8 @@
             >"hide arrchived items"
           </q-tooltip>
         </div>
-      </div>
-    </ul>
+      </template>
+    </BaseAccordion>
   </div>
 </template>
 
@@ -88,12 +83,15 @@ import {
   lsLoadCheckedFieldNames,
   lsStoreCheckedFieldNames,
 } from "@/services/localStorageManager";
+import { fieldsSchema } from "@/assets/nativeFields";
+import BaseCheckbox from "@/components/base/BaseCheckbox.vue";
+import BaseAccordion from "@/components/base/BaseAccordion.vue";
 
 export default {
+  components: { BaseCheckbox, BaseAccordion },
   data() {
     return {
       defaultColumns: {},
-      isDisplayedArray: [true],
       hideArchived: false, // for the q-toggle
     };
   },
@@ -153,6 +151,39 @@ export default {
     ...mapActions(useAppStore, ["SetIsArchivedItemsHided"]),
     changeLang(lang) {
       this.setLang(lang);
+    },
+    isGroupAllChecked(group) {
+      return (
+        group.fields.length > 0 &&
+        group.fields.every((f) => this.checkedFieldNames.includes(f.field))
+      );
+    },
+    checkFieldGroup(group) {
+      const groupFieldNames = group.fields.map((f) => f.field);
+      const uniqueCheckedFieldNames = new Set(this.checkedFieldNames);
+      if (this.isGroupAllChecked(group)) {
+        groupFieldNames.forEach((name) => uniqueCheckedFieldNames.delete(name));
+      } else {
+        groupFieldNames.forEach((name) => uniqueCheckedFieldNames.add(name));
+      }
+      this.checkedFieldNames = [...uniqueCheckedFieldNames];
+    },
+    toggleField(fieldName, checked) {
+      const uniqueCheckedFieldNames = new Set(this.checkedFieldNames);
+      if (checked) {
+        uniqueCheckedFieldNames.add(fieldName);
+      } else {
+        uniqueCheckedFieldNames.delete(fieldName);
+      }
+      this.checkedFieldNames = [...uniqueCheckedFieldNames];
+    },
+    fieldLabel(field) {
+      return (
+        field.labels?.[this.lang] ||
+        this.projectPreferencesFieldsWithTranslation?.[field.field] ||
+        fieldsSchema?.[field.field]?.labels?.[this.lang] ||
+        field.field
+      );
     },
   },
 };

--- a/src/components/TheControlTrenches.vue
+++ b/src/components/TheControlTrenches.vue
@@ -46,72 +46,46 @@
       </q-card>
     </q-dialog>
     <!-- liste trenches -->
-    <div v-if="projectTrenchesNames.length < 15">
-      <ul
-        v-for="trenchName in projectTrenchesNames"
-        :key="trenchName"
-        class="list-group"
-      >
-        <li class="list-group-item accordion">
-          <input
-            id="trench-checkbox"
-            v-model="checkedTrenchesNames"
-            type="checkbox"
-            :value="trenchName"
-          />
-          <label class="px-1 m-0" for="trench-checkbox">{{ trenchName }}</label>
-        </li>
-      </ul>
+    <div v-if="trenchNames.length < 15" class="py-1">
+      <div v-for="trenchName in trenchNames" :key="trenchName">
+        <BaseCheckbox
+          :model-value="checkedTrenchesNames.includes(trenchName)"
+          :label="trenchName"
+          @update:model-value="
+            (checked) => toggleTrench(trenchName, checked)
+          "
+        />
+      </div>
     </div>
     <div v-else>
-      <ul
-        v-for="(trenchGroupName, index) in accordionLabels"
-        :key="trenchGroupName"
-        class="list-group"
+      <BaseAccordion
+        v-for="(trenchGroup, index) in groupedTrenches"
+        :key="trenchGroup.name"
+        :initial-open="index === 0"
+        :toggle-aria-label="`Toggle ${trenchGroup.name}`"
       >
-        <li
-          class="list-group-item accordion text-bold"
-          @click="isDisplayedArray[index] = !isDisplayedArray[index]"
-        >
-          <label class="px-1 m-0 text-bold" for="checkbox">
-            <q-icon
-              v-if="isDisplayedArray[index]"
-              name="keyboard_arrow_down"
-            /><q-icon
-              v-if="!isDisplayedArray[index]"
-              name="keyboard_arrow_right"
-            />{{ trenchGroupName }}</label
-          >
-          <input
-            v-model="isCheckedArray[index]"
-            type="checkbox"
-            @change="checkGroup(trenchGroupName, isCheckedArray[index])"
+        <template #title>
+          <BaseCheckbox
+            class="text-bold"
+            :model-value="isGroupAllChecked(trenchGroup.trenches)"
+            :label="trenchGroup.name"
+            @update:model-value="
+              (checked) => checkGroup(trenchGroup.trenches, checked)
+            "
           />
-        </li>
-        <!-- liste trenches -->
-        <div v-if="isDisplayedArray[index]">
-          <ul
-            v-for="trenchName in projectTrenchesNames"
-            :key="trenchName"
-            class="list-group"
-          >
-            <li
-              v-if="trenchName.includes(trenchGroupName)"
-              class="list-group-item accordion"
-            >
-              <input
-                id="trench-checkbox"
-                v-model="checkedTrenchesNames"
-                type="checkbox"
-                :value="trenchName"
-              />
-              <label class="px-1 m-0" for="trench-checkbox">{{
-                trenchName
-              }}</label>
-            </li>
-          </ul>
-        </div>
-      </ul>
+        </template>
+        <template #content>
+          <div v-for="trenchName in trenchGroup.trenches" :key="trenchName">
+            <BaseCheckbox
+              :model-value="checkedTrenchesNames.includes(trenchName)"
+              :label="trenchName"
+              @update:model-value="
+                (checked) => toggleTrench(trenchName, checked)
+              "
+            />
+          </div>
+        </template>
+      </BaseAccordion>
     </div>
   </div>
 </template>
@@ -119,12 +93,13 @@
 <script>
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useDataStore } from "@/stores/data";
+import BaseAccordion from "@/components/base/BaseAccordion.vue";
+import BaseCheckbox from "@/components/base/BaseCheckbox.vue";
 
 export default {
+  components: { BaseAccordion, BaseCheckbox },
   data() {
     return {
-      isDisplayedArray: [],
-      isCheckedArray: [],
       isAllChecked: false,
       toAllChecked: false,
       confirmAllChecked: false,
@@ -133,11 +108,22 @@ export default {
   computed: {
     ...mapState(useDataStore, ["projectTrenchesNames", "checkedTrenchesItems"]),
     ...mapWritableState(useDataStore, ["checkedTrenchesNames"]), // mapWritableState for v-model only
+    trenchNames() {
+      return this.projectTrenchesNames ?? [];
+    },
     accordionLabels() {
       // create groups by 5 first caracters and send reverse order
-      return [...new Set(this.projectTrenchesNames?.map((x) => x.substr(0, 5)))]
+      return [...new Set(this.trenchNames.map((x) => x.substr(0, 5)))]
         .sort()
         .reverse();
+    },
+    groupedTrenches() {
+      return this.accordionLabels.map((name) => ({
+        name,
+        trenches: this.trenchNames.filter((trenchName) =>
+          trenchName.includes(name),
+        ),
+      }));
     },
   },
   watch: {
@@ -151,7 +137,7 @@ export default {
       this.removeCheckedTrenchesData(removedTrenches);
       this.addCheckedTrenchesData(addedTrenches);
 
-      if (newTrenchList.length === this.projectTrenchesNames.length) {
+      if (newTrenchList.length === this.trenchNames.length) {
         this.isAllChecked = true;
       } else if (newTrenchList.length === 0) {
         this.isAllChecked = false;
@@ -169,7 +155,7 @@ export default {
     ]),
     handleCheckboxUpdate(value) {
       if (value === true) {
-        if (this.projectTrenchesNames.length > 15) {
+        if (this.trenchNames.length > 15) {
           this.confirmAllChecked = true;
         } else {
           this.checkAll();
@@ -179,26 +165,40 @@ export default {
       }
     },
     checkAll() {
-      this.setCheckedTrenchesNames([...this.projectTrenchesNames]);
-      this.isCheckedArray = this.accordionLabels.map(() => true);
+      this.setCheckedTrenchesNames([...this.trenchNames]);
     },
     uncheckAll() {
       this.setCheckedTrenchesNames([]);
-      this.isCheckedArray = this.accordionLabels.map(() => false);
     },
-    checkGroup(checkGroup, checked) {
+    isGroupAllChecked(groupTrenches) {
+      return (
+        groupTrenches.length > 0 &&
+        groupTrenches.every((trenchName) =>
+          this.checkedTrenchesNames.includes(trenchName),
+        )
+      );
+    },
+    checkGroup(groupTrenches, checked) {
+      const uniqueCheckedTrenchesNames = new Set(this.checkedTrenchesNames);
       if (checked) {
-        let newCheckedTrenchesNames = this.checkedTrenchesNames.concat(
-          this.projectTrenchesNames.filter((item) => item.includes(checkGroup)),
+        groupTrenches.forEach((trenchName) =>
+          uniqueCheckedTrenchesNames.add(trenchName),
         );
-        this.setCheckedTrenchesNames(newCheckedTrenchesNames);
       } else {
-        // Removes items from checkGroup and checkedTrenchesNames
-        let filteredCheckedTrenchesNames = this.checkedTrenchesNames.filter(
-          (item) => !item.includes(checkGroup),
+        groupTrenches.forEach((trenchName) =>
+          uniqueCheckedTrenchesNames.delete(trenchName),
         );
-        this.setCheckedTrenchesNames(filteredCheckedTrenchesNames);
       }
+      this.setCheckedTrenchesNames([...uniqueCheckedTrenchesNames]);
+    },
+    toggleTrench(trenchName, checked) {
+      const uniqueCheckedTrenchesNames = new Set(this.checkedTrenchesNames);
+      if (checked) {
+        uniqueCheckedTrenchesNames.add(trenchName);
+      } else {
+        uniqueCheckedTrenchesNames.delete(trenchName);
+      }
+      this.setCheckedTrenchesNames([...uniqueCheckedTrenchesNames]);
     },
   },
 };

--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -7,7 +7,7 @@
   <ThePatches v-if="syncPatches" @clear-the-item="clearTheItem()"></ThePatches>
   <TheItem v-if="selectedItem"> </TheItem>
 
-  <q-bar Class="bg-grey-1 full-width row ">
+  <q-bar class="bg-grey-1 full-width row">
     <div class="q-align-center">
       <q-btn
         :size="'sm'"
@@ -23,6 +23,11 @@
       >
     </div>
     <q-space />
+    <div class="text-grey-8 q-px-sm small">
+      {{
+        $t("app.items", { count: displayedItemsCount }, displayedItemsCount)
+      }}
+    </div>
     <div>
       <q-btn
         v-if="tableEditMode && editedCells.length > 0"
@@ -65,7 +70,6 @@ import { applyPlugin } from "jspdf-autotable";
 applyPlugin(jsPDF);
 import { openDB, readDataInIndexedDB } from "@/services/indexedDbManager";
 import { pushSurvey } from "@/services/pushSurveyService";
-import { DateTime } from "luxon";
 
 export default {
   name: "TheTable",
@@ -97,8 +101,15 @@ export default {
       "projectPreferencesTypesTranslationPlurals",
       "projectPreferencesTypesTranslation",
       "checkedTrenchesItemsSelectedTypeAndSearched",
+      "tableFilteredCheckedTrenchesItems",
       "projectPreferencesBase64",
     ]),
+
+    displayedItemsCount() {
+      return this.tableFilteredCheckedTrenchesItems
+        ? this.tableFilteredCheckedTrenchesItems.length
+        : this.checkedTrenchesItemsSelectedTypeAndSearched.length;
+    },
 
     columnsTabulator() {
       var headerMenu = [
@@ -139,13 +150,13 @@ export default {
         },
         {
           label: "Ungroup or clear",
-          action: (e, column) => {
+          action: () => {
             this.tabulator.setGroupBy(false);
             this.tabulator.clearFilter();
           },
         },
       ];
-      function printFormatter(cell, formatterParams, onRendered) {
+      function printFormatter(cell) {
         if (
           cell.getField() === "DateEarliest" ||
           cell.getField() === "DateLatest"
@@ -271,7 +282,7 @@ export default {
       },
     );
 
-    this.tabulator.on("cellEdited", (cell) => {
+    this.tabulator.on("cellEdited", () => {
       this.editedCells = this.tabulator.getEditedCells();
     });
 
@@ -294,7 +305,7 @@ export default {
       if (rows && rows.length) {
         try {
           activeData = rows.map((r) => r.getData());
-        } catch (e) {
+        } catch {
           activeData = null;
         }
       }

--- a/src/components/__tests__/TheControlTrenches.spec.js
+++ b/src/components/__tests__/TheControlTrenches.spec.js
@@ -12,6 +12,18 @@ describe("TheControlTrenches", () => {
     const wrapper = mount(TheControlTrenches, {
       global: {
         plugins: [pinia], // Add Pinia as a plugin globally
+        mocks: {
+          $t: (key) => (key === "app.trenches" ? "Secteurs" : key),
+        },
+        stubs: {
+          "q-checkbox": true,
+          "q-tooltip": true,
+          "q-dialog": true,
+          "q-card": true,
+          "q-card-section": true,
+          "q-card-actions": true,
+          "q-btn": true,
+        },
       },
       props: { projectTrenchesNames: [] },
     });

--- a/src/components/base/BaseAccordion.vue
+++ b/src/components/base/BaseAccordion.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="base-accordion">
+    <div class="base-accordion__header d-flex align-items-center px-1">
+      <BaseButton
+        :icon="isOpen ? 'keyboard_arrow_down' : 'keyboard_arrow_right'"
+        icon-size="sm"
+        :aria-label="toggleAriaLabel"
+        class="mr-1"
+        @click="toggle"
+      />
+      <slot name="title" />
+    </div>
+    <div v-if="isOpen" class="py-1 pl-4">
+      <slot name="content" />
+    </div>
+  </div>
+</template>
+
+<script>
+import BaseButton from "@/components/base/BaseButton.vue";
+
+export default {
+  name: "BaseAccordion",
+  components: { BaseButton },
+  props: {
+    initialOpen: { type: Boolean, default: false },
+    toggleAriaLabel: { type: String, default: "Toggle section" },
+  },
+  data() {
+    return {
+      isOpen: this.initialOpen,
+    };
+  },
+  methods: {
+    toggle() {
+      this.isOpen = !this.isOpen;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.base-accordion + .base-accordion {
+  border-top: 1px solid #e5e5e5;
+}
+.base-accordion__header {
+  transition: background-color 0.15s;
+}
+.base-accordion__header:hover {
+  background-color: #ececec;
+}
+</style>

--- a/src/components/base/BaseButton.vue
+++ b/src/components/base/BaseButton.vue
@@ -1,0 +1,54 @@
+<template>
+  <button
+    type="button"
+    :class="[
+      disabled && 'cursor-not-allowed',
+      !disabled && 'cursor-pointer',
+      'base-button d-inline-flex align-items-center p-0 bg-transparent border-0',
+    ]"
+    :aria-label="ariaLabel || undefined"
+    :disabled="disabled"
+  >
+    <BaseIcon
+      v-if="icon"
+      :name="icon"
+      :size="iconSize"
+      :class="[label && 'mr-1']"
+    />
+    <span v-if="label">{{ label }}</span>
+  </button>
+</template>
+
+<script>
+import BaseIcon from "@/components/base/BaseIcon.vue";
+
+export default {
+  name: "BaseButton",
+  components: { BaseIcon },
+  props: {
+    label: { type: String, default: "" },
+    icon: { type: String, default: "" },
+    iconSize: { type: String, default: "" },
+    disabled: { type: Boolean, default: false },
+    ariaLabel: { type: String, default: "" },
+  },
+};
+</script>
+
+<style scoped>
+.base-button {
+  font: inherit;
+  color: inherit;
+}
+.base-button:disabled {
+  opacity: 0.6;
+}
+.base-button:focus {
+  outline: none;
+}
+.base-button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+</style>

--- a/src/components/base/BaseCheckbox.vue
+++ b/src/components/base/BaseCheckbox.vue
@@ -1,0 +1,36 @@
+<template>
+  <label
+    :class="[
+      disabled && 'cursor-not-allowed base-checkbox--disabled',
+      !disabled && 'cursor-pointer',
+      'd-inline-flex items-center non-selectable m-0',
+    ]"
+  >
+    <input
+      type="checkbox"
+      class="mr-1"
+      :checked="modelValue"
+      :disabled="disabled"
+      @change="$emit('update:modelValue', $event.target.checked)"
+    />
+    <span>{{ label }}</span>
+  </label>
+</template>
+
+<script>
+export default {
+  name: "BaseCheckbox",
+  props: {
+    modelValue: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    label: { type: String, required: true },
+  },
+  emits: ["update:modelValue"],
+};
+</script>
+
+<style scoped>
+.base-checkbox--disabled {
+  opacity: 0.6;
+}
+</style>

--- a/src/components/base/BaseIcon.vue
+++ b/src/components/base/BaseIcon.vue
@@ -1,0 +1,13 @@
+<template>
+  <q-icon :name="name" :size="size || undefined" />
+</template>
+
+<script>
+export default {
+  name: "BaseIcon",
+  props: {
+    name: { type: String, required: true },
+    size: { type: String, default: "" },
+  },
+};
+</script>

--- a/src/components/base/__tests__/BaseAccordion.spec.js
+++ b/src/components/base/__tests__/BaseAccordion.spec.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import BaseAccordion from "@/components/base/BaseAccordion.vue";
+
+const globalStubs = { global: { stubs: { "q-icon": true } } };
+
+describe("BaseAccordion", () => {
+  it("should render the title slot", () => {
+    const wrapper = mount(BaseAccordion, {
+      slots: { title: "<span>Title content</span>" },
+      ...globalStubs,
+    });
+    expect(wrapper.text()).toContain("Title content");
+  });
+
+  it("should not render the content slot when closed by default", () => {
+    const wrapper = mount(BaseAccordion, {
+      slots: { content: "<span>Content body</span>" },
+      ...globalStubs,
+    });
+    expect(wrapper.text()).not.toContain("Content body");
+  });
+
+  it("should render the content slot when initialOpen is true", () => {
+    const wrapper = mount(BaseAccordion, {
+      props: { initialOpen: true },
+      slots: { content: "<span>Content body</span>" },
+      ...globalStubs,
+    });
+    expect(wrapper.text()).toContain("Content body");
+  });
+
+  it("should toggle the content visibility when the chevron button is clicked", async () => {
+    const wrapper = mount(BaseAccordion, {
+      slots: { content: "<span>Content body</span>" },
+      ...globalStubs,
+    });
+    expect(wrapper.text()).not.toContain("Content body");
+
+    await wrapper.find("button").trigger("click");
+    expect(wrapper.text()).toContain("Content body");
+
+    await wrapper.find("button").trigger("click");
+    expect(wrapper.text()).not.toContain("Content body");
+  });
+
+  it("should expose a button element for the toggle (keyboard accessible)", () => {
+    const wrapper = mount(BaseAccordion, globalStubs);
+    const button = wrapper.find("button");
+    expect(button.exists()).toBe(true);
+    expect(button.attributes("type")).toBe("button");
+  });
+});

--- a/src/components/base/__tests__/BaseButton.spec.js
+++ b/src/components/base/__tests__/BaseButton.spec.js
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import BaseButton from "@/components/base/BaseButton.vue";
+
+const globalStubs = { global: { stubs: { "q-icon": true } } };
+
+describe("BaseButton", () => {
+  it("should render a native button element with type button", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { label: "Click" }, ...globalStubs },
+    );
+    expect(wrapper.element.tagName).toBe("BUTTON");
+    expect(wrapper.attributes("type")).toBe("button");
+  });
+
+  it("should render the label as text when label prop is provided", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { label: "Click me" }, ...globalStubs },
+    );
+    expect(wrapper.text()).toContain("Click me");
+  });
+
+  it("should render an icon when icon prop is provided", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { icon: "home", ariaLabel: "Home" }, ...globalStubs },
+    );
+    expect(wrapper.findComponent({ name: "BaseIcon" }).exists()).toBe(true);
+  });
+
+  it("should render both label and icon when both are provided", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { label: "Home", icon: "home" }, ...globalStubs },
+    );
+    expect(wrapper.text()).toContain("Home");
+    expect(wrapper.findComponent({ name: "BaseIcon" }).exists()).toBe(true);
+  });
+
+  it("should emit click when the button is clicked", async () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { label: "Click" }, ...globalStubs },
+    );
+    await wrapper.trigger("click");
+    expect(wrapper.emitted("click")).toHaveLength(1);
+  });
+
+  it("should apply the disabled attribute when disabled prop is true", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { label: "x", disabled: true }, ...globalStubs },
+    );
+    expect(wrapper.attributes("disabled")).toBeDefined();
+  });
+
+  it("should set aria-label from prop for icon-only buttons", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { icon: "home", ariaLabel: "Go home" }, ...globalStubs },
+    );
+    expect(wrapper.attributes("aria-label")).toBe("Go home");
+  });
+
+  it("should not render aria-label attribute when no ariaLabel is provided", () => {
+    const wrapper = mount(
+      BaseButton,
+      { props: { label: "Click" }, ...globalStubs },
+    );
+    expect(wrapper.attributes("aria-label")).toBeUndefined();
+  });
+});

--- a/src/components/base/__tests__/BaseCheckbox.spec.js
+++ b/src/components/base/__tests__/BaseCheckbox.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import BaseCheckbox from "../BaseCheckbox.vue";
+
+describe("BaseCheckbox", () => {
+  it("should render a checkbox input wrapped in a label", () => {
+    const wrapper = mount(BaseCheckbox, { props: { label: "My label" } });
+    expect(wrapper.element.tagName).toBe("LABEL");
+
+    const input = wrapper.find("input");
+    expect(input.exists()).toBe(true);
+    expect(input.attributes("type")).toBe("checkbox");
+  });
+
+  it("should render the label prop as text", () => {
+    const wrapper = mount(BaseCheckbox, { props: { label: "My label" } });
+    expect(wrapper.text()).toContain("My label");
+  });
+
+  it("should reflect the modelValue prop in the checked state", async () => {
+    const wrapper = mount(BaseCheckbox, {
+      props: { label: "x", modelValue: true },
+    });
+    expect(wrapper.find("input").element.checked).toBe(true);
+
+    await wrapper.setProps({ modelValue: false });
+    expect(wrapper.find("input").element.checked).toBe(false);
+  });
+
+  it("should emit update:modelValue with the new checked state when toggled", async () => {
+    const wrapper = mount(BaseCheckbox, {
+      props: { label: "x", modelValue: false },
+    });
+    await wrapper.find("input").setValue(true);
+
+    const events = wrapper.emitted("update:modelValue");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual([true]);
+  });
+
+  it("should apply the disabled attribute to the input when disabled prop is true", () => {
+    const wrapper = mount(BaseCheckbox, {
+      props: { label: "x", disabled: true },
+    });
+    expect(wrapper.find("input").attributes("disabled")).toBeDefined();
+  });
+
+  it("should pass through fallthrough attributes to the root label", () => {
+    const wrapper = mount(BaseCheckbox, {
+      props: { label: "x" },
+      attrs: { class: "ml-1" },
+    });
+    expect(wrapper.classes()).toContain("ml-1");
+  });
+});

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,6 +1,8 @@
 {
   "app": {
     "fields": "Felder",
+    "items": "{count} Eintrag | {count} Einträge",
+    "toggle_group": "{name} ein-/ausklappen",
     "trenches": "Sektoren",
     "trenche": "Sektor",
     "loaded": "Geladen",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1,6 +1,8 @@
 {
   "app": {
     "fields": "Πεδία",
+    "items": "{count} στοιχείο | {count} στοιχεία",
+    "toggle_group": "Εναλλαγή {name}",
     "trenches": "Τομείς",
     "trenche": "Τομέας",
     "loaded": "Φορτώθηκε",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,8 @@
 {
   "app": {
     "fields": "Fields",
+    "items": "{count} item | {count} items",
+    "toggle_group": "Toggle {name}",
     "trenches": "Sectors",
     "trenche": "Sector",
     "loaded": "loaded",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,6 +1,8 @@
 {
   "app": {
     "fields": "Champs",
+    "items": "{count} item | {count} items",
+    "toggle_group": "Plier/Déplier {name}",
     "trenches": "Secteurs",
     "trenche": "Secteur",
     "loaded": "chargé",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1,6 +1,8 @@
 {
   "app": {
     "fields": "Campi",
+    "items": "{count} elemento | {count} elementi",
+    "toggle_group": "Mostra/Nascondi {name}",
     "trenches": "Settori",
     "trenche": "Settore",
     "loaded": "caricato",


### PR DESCRIPTION
**Issue** :  https://github.com/esag-swiss/iDig-Webapp/issues/216

**Description** :    
* Case à cocher par groupe de champs (toggle tout le groupe via `Set`) + compteur d'items filtrés dans le header du tableau, avec pluralisation i18n.

<img width="1247" height="958" alt="image" src="https://github.com/user-attachments/assets/44546e24-0b82-442b-bc88-0da9379e0aa4" />

**Refactor**
* Création de 4 composants de base dans `src/components/base/` : `BaseIcon` (wrapper q-icon), `BaseCheckbox`, `BaseButton`, `BaseAccordion`. 
* `TheControlFields.vue` utilise désormais ces primitives.

**A11y**
* Vrai `<button>` keyboard-accessible pour le chevron d'accordéon (vs `<q-icon>` non-focusable avant).
* `<label>` natif wrappant l'input dans `BaseCheckbox` (fix du `for="checkbox"` cassé qui pointait sur le même id partout).
* `:focus-visible` pour ne montrer l'outline qu'au focus clavier, `aria-label` traduit sur le toggle.

**Conventions adoptées** 
* Utility classes Bootstrap 4 / Quasar en priorité (`<style>` uniquement pour ce qu'aucune ne propose).
* Imports absolus `@/…` partout, tests `.spec.js` (pas de TS dans le projet).

**Tests**
* Ajout de 19 tests sur les 3 composants de base (BaseCheckbox 6, BaseButton 8, BaseAccordion 5).

