### PR TITLE
feat(crs): detect EPSG / WKT / PROJ4 formats from preferences

### DIFF
--- a/src/services/__tests__/coordinateUtils.spec.js
+++ b/src/services/__tests__/coordinateUtils.spec.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import proj4 from "proj4";
+import {
+  CRS_FORMAT,
+  detectCrsFormat,
+  resolveProjectCrs,
+  convertToEPSG4326,
+} from "@/services/coordinateUtils";
+
+describe("detectCrsFormat", () => {
+  it("should recognise EPSG codes with and without prefix", () => {
+    expect(detectCrsFormat("EPSG:2100")).toBe(CRS_FORMAT.EPSG);
+    expect(detectCrsFormat("epsg:32634")).toBe(CRS_FORMAT.EPSG);
+    expect(detectCrsFormat("2100")).toBe(CRS_FORMAT.EPSG);
+  });
+
+  it("should recognise PROJ4 strings", () => {
+    expect(
+      detectCrsFormat("+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000")
+    ).toBe(CRS_FORMAT.PROJ4);
+    expect(detectCrsFormat("  +proj=longlat +datum=WGS84 +no_defs")).toBe(
+      CRS_FORMAT.PROJ4
+    );
+  });
+
+  it("should recognise WKT strings", () => {
+    expect(
+      detectCrsFormat('PROJCS["GGRS87 / Greek Grid",GEOGCS["GGRS87",...]]')
+    ).toBe(CRS_FORMAT.WKT);
+    expect(detectCrsFormat('GEOGCRS["WGS 84",DATUM["WGS_1984",...]]')).toBe(
+      CRS_FORMAT.WKT
+    );
+  });
+
+  it("should recognise hardcoded named CRS", () => {
+    expect(detectCrsFormat("Amarynthos")).toBe(CRS_FORMAT.NAMED);
+    expect(detectCrsFormat("Agora")).toBe(CRS_FORMAT.NAMED);
+    expect(detectCrsFormat("UTM zone 34")).toBe(CRS_FORMAT.NAMED);
+  });
+
+  it("should return UNKNOWN for empty or non-string input", () => {
+    expect(detectCrsFormat("")).toBe(CRS_FORMAT.UNKNOWN);
+    expect(detectCrsFormat("   ")).toBe(CRS_FORMAT.UNKNOWN);
+    expect(detectCrsFormat(null)).toBe(CRS_FORMAT.UNKNOWN);
+    expect(detectCrsFormat(undefined)).toBe(CRS_FORMAT.UNKNOWN);
+    expect(detectCrsFormat(2100)).toBe(CRS_FORMAT.UNKNOWN);
+  });
+
+  it("should return UNKNOWN for unrecognised free text", () => {
+    expect(detectCrsFormat("SomeProjectWeDoNotKnow")).toBe(CRS_FORMAT.UNKNOWN);
+  });
+});
+
+describe("resolveProjectCrs", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("should return the value as-is for a known named CRS", () => {
+    expect(resolveProjectCrs("Amarynthos", "Amarynthos")).toBe("Amarynthos");
+    expect(resolveProjectCrs("Agora", "Agora")).toBe("Agora");
+  });
+
+  it("should normalise EPSG codes and accept bare numeric codes", () => {
+    expect(resolveProjectCrs("epsg:2100", "Amarynthos")).toBe("EPSG:2100");
+    expect(resolveProjectCrs("2100", "Amarynthos")).toBe("EPSG:2100");
+  });
+
+  it("should fall back to the project name for unknown EPSG codes", () => {
+    expect(resolveProjectCrs("EPSG:9999", "Amarynthos")).toBe("Amarynthos");
+  });
+
+  it("should register PROJ4 strings dynamically and return a stable key", () => {
+    const key = resolveProjectCrs(
+      "+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000 +y_0=0 +datum=GGRS87 +units=m +no_defs",
+      "MyCustomProject"
+    );
+    expect(key).toBe("MyCustomProject__fromPreferences");
+    expect(proj4.defs(key)).toBeTruthy();
+  });
+
+  it("should register WKT strings dynamically", () => {
+    const wkt =
+      'PROJCS["GGRS87 / Greek Grid",GEOGCS["GGRS87",DATUM["Greek_Geodetic_Reference_System_1987",SPHEROID["GRS 1980",6378137,298.257222101]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",24],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1]]';
+    const key = resolveProjectCrs(wkt, "WktProject");
+    expect(key).toBe("WktProject__fromPreferences");
+    expect(proj4.defs(key)).toBeTruthy();
+  });
+
+  it("should fall back to the hardcoded project name when crs is missing", () => {
+    expect(resolveProjectCrs(undefined, "Agora")).toBe("Agora");
+    expect(resolveProjectCrs(null, "Amarynthos")).toBe("Amarynthos");
+    expect(resolveProjectCrs("", "Agora")).toBe("Agora");
+  });
+
+  it("should return null when no fallback is available", () => {
+    expect(resolveProjectCrs(undefined, "UnknownProject")).toBeNull();
+    expect(resolveProjectCrs("ZeroIdea", "AlsoUnknown")).toBeNull();
+  });
+});
+
+describe("convertToEPSG4326", () => {
+  it("should convert coordinates using a resolved CRS key", () => {
+    const key = resolveProjectCrs("Amarynthos", "Amarynthos");
+    const { coords } = convertToEPSG4326([100000, 0], key);
+    expect(Array.isArray(coords)).toBe(true);
+    expect(coords).toHaveLength(2);
+    expect(coords.every(Number.isFinite)).toBe(true);
+  });
+
+  it("should work after dynamic registration of a PROJ4 string", () => {
+    const key = resolveProjectCrs(
+      "+proj=utm +zone=34 +datum=WGS84 +units=m +no_defs",
+      "DynamicUtm"
+    );
+    const { coords } = convertToEPSG4326([500000, 4000000], key);
+    expect(coords.every(Number.isFinite)).toBe(true);
+  });
+});

--- a/src/services/coordinateUtils.js
+++ b/src/services/coordinateUtils.js
@@ -31,10 +31,165 @@ proj4.defs([
   ],
 ]);
 
-export function convertToEPSG4326(xyArray, crs) {
-  let sourceSystem = crs;
-  let targetSystem = "EPSG:4326";
+// Legacy named CRS resolved via the proj4.defs registered above. Used as a
+// fallback when the `crs` field in Preferences.json is a project name rather
+// than a real EPSG / WKT / PROJ4 string.
+const HARDCODED_CRS_NAMES = new Set([
+  "EPSG:2100",
+  "GGRS87",
+  "AEO_Aegina",
+  "Amarynthos",
+  "EPSG:4326",
+  "WGS84",
+  "EPSG:32634",
+  "UTM zone 34",
+  "EPSG:32635",
+  "UTM zone 35",
+  "Agora",
+]);
 
-  const coords = proj4(sourceSystem, targetSystem, xyArray);
+export const CRS_FORMAT = Object.freeze({
+  EPSG: "epsg",
+  WKT: "wkt",
+  PROJ4: "proj4",
+  NAMED: "named",
+  UNKNOWN: "unknown",
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Format detection
+// ───────────────────────────────────────────────────────────────────────────
+
+const EPSG_WITH_PREFIX_REGEX = /^EPSG:\d+$/i;
+const EPSG_BARE_NUMERIC_REGEX = /^\d{4,6}$/;
+const PROJ4_PREFIX_REGEX = /^\+proj=/i;
+const WKT_ROOT_KEYWORD_REGEX =
+  /^(PROJCS|GEOGCS|PROJCRS|GEOGCRS|GEOCCS|COMPDCS|COMPD_CS|VERT_CS|VERTCRS|BOUNDCRS|ENGCRS|TIMECRS)\s*\[/i;
+
+const isEpsg = (value) =>
+  EPSG_WITH_PREFIX_REGEX.test(value) || EPSG_BARE_NUMERIC_REGEX.test(value);
+const isProj4 = (value) => PROJ4_PREFIX_REGEX.test(value);
+const isWkt = (value) => WKT_ROOT_KEYWORD_REGEX.test(value);
+const isNamedCrs = (value) => HARDCODED_CRS_NAMES.has(value);
+
+const FORMAT_DETECTORS = [
+  [isEpsg, CRS_FORMAT.EPSG],
+  [isProj4, CRS_FORMAT.PROJ4],
+  [isWkt, CRS_FORMAT.WKT],
+  [isNamedCrs, CRS_FORMAT.NAMED],
+];
+
+function trimmedOrNull(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+// Detect the format of a CRS string read from Preferences.json.
+// EPSG: "EPSG:2100", "epsg:2100", or a bare numeric code like "2100".
+// PROJ4: starts with "+proj=" (with optional leading whitespace).
+// WKT: starts with one of the standard WKT root keywords + "[".
+// NAMED: matches a known hardcoded label (Amarynthos, Agora, ...).
+export function detectCrsFormat(crsValue) {
+  const value = trimmedOrNull(crsValue);
+  if (!value) {
+    return CRS_FORMAT.UNKNOWN;
+  }
+  const match = FORMAT_DETECTORS.find(([test]) => test(value));
+  return match ? match[1] : CRS_FORMAT.UNKNOWN;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// proj4 helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+function normalizeEpsgCode(value) {
+  const code = EPSG_WITH_PREFIX_REGEX.test(value) ? value.split(":")[1] : value;
+  return `EPSG:${code}`;
+}
+
+function hasProj4Def(key) {
+  try {
+    return Boolean(proj4.defs(key));
+  } catch {
+    return false;
+  }
+}
+
+function tryRegisterProj4Def(key, definition) {
+  try {
+    proj4.defs(key, definition);
+    return true;
+  } catch (e) {
+    console.warn(
+      `[coordinateUtils] Failed to register "${key}": ${e?.message}.`,
+    );
+    return false;
+  }
+}
+
+function buildCustomCrsKey(projectName, value) {
+  return projectName ? `${projectName}__fromPreferences` : value;
+}
+
+function warnFallback(reason, fallbackKey) {
+  const target = fallbackKey ? `"${fallbackKey}"` : "none";
+  console.warn(`[coordinateUtils] ${reason} Falling back to ${target}.`);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Resolver
+// ───────────────────────────────────────────────────────────────────────────
+
+// Resolve the `crs` field from Preferences.json to a proj4 key usable with
+// convertToEPSG4326. Registers WKT / PROJ4 strings on the fly; falls back
+// to the hardcoded named definitions when the value is unrecognised.
+export function resolveProjectCrs(crsValue, projectName) {
+  const fallbackKey =
+    projectName && hasProj4Def(projectName) ? projectName : null;
+
+  const value = trimmedOrNull(crsValue);
+  if (!value) {
+    return fallbackKey;
+  }
+
+  switch (detectCrsFormat(value)) {
+    case CRS_FORMAT.NAMED:
+      return value;
+
+    case CRS_FORMAT.EPSG: {
+      const key = normalizeEpsgCode(value);
+      if (hasProj4Def(key)) {
+        return key;
+      }
+      warnFallback(`EPSG code "${key}" is not registered.`, fallbackKey);
+      return fallbackKey;
+    }
+
+    case CRS_FORMAT.WKT:
+    case CRS_FORMAT.PROJ4: {
+      const key = buildCustomCrsKey(projectName, value);
+      return tryRegisterProj4Def(key, value) ? key : fallbackKey;
+    }
+
+    default:
+      // Unknown format: maybe it's a name we know via proj4 but not in our
+      // hardcoded map (or registered earlier). Try it before falling back.
+      if (hasProj4Def(value)) {
+        return value;
+      }
+      warnFallback(`Unknown CRS "${value}".`, fallbackKey);
+      return fallbackKey;
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Coordinate conversion
+// ───────────────────────────────────────────────────────────────────────────
+
+export function convertToEPSG4326(xyArray, crs) {
+  const coords = proj4(crs, "EPSG:4326", xyArray);
   return { coords };
 }

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -17,6 +17,7 @@ import {
   readDataInIndexedDB,
 } from "@/services/indexedDbManager";
 import { fieldsSchema } from "@/assets/nativeFields";
+import { resolveProjectCrs } from "@/services/coordinateUtils";
 
 export const useDataStore = defineStore("data", {
   state: () => ({
@@ -332,11 +333,12 @@ export const useDataStore = defineStore("data", {
           });
           throw e;
         }
-        if (cleanPreferences.crs) {
-          this.setProjectPreferencesCrs(cleanPreferences.crs);
-        } else if (cleanPreferences.project === "Agora") {
-          // Agora project doesn't have property CRS
-          this.setProjectPreferencesCrs(cleanPreferences.project);
+        const resolvedCrs = resolveProjectCrs(
+          cleanPreferences.crs,
+          cleanPreferences.project
+        );
+        if (resolvedCrs) {
+          this.setProjectPreferencesCrs(resolvedCrs);
         }
         this.setProjectPreferencesTypes(cleanPreferences.types);
         this.setProjectPreferencesFields(cleanPreferences.fields);


### PR DESCRIPTION
**Issue** :  https://github.com/esag-swiss/iDig-Webapp/issues/217

**Description** :    
Détection automatique du format du `crs` lu dans `Preferences.json` (EPSG, WKT, PROJ4 ou nom hérité). Les chaînes WKT/PROJ4 sont enregistrées dynamiquement dans proj4 ; les valeurs inconnues retombent sur les définitions hardcodées historiques (Amarynthos, Agora, UTM zones, etc.).

## Refactor

- `src/services/coordinateUtils.js` : ajout de `detectCrsFormat()` et `resolveProjectCrs()`. Le bloc `proj4.defs([...])` existant est conservé intact (diff purement additif).
- `src/stores/data.js` : `fetchAndLoadPreferences()` passe désormais par `resolveProjectCrs(cleanPreferences.crs, cleanPreferences.project)` — disparition du cas spécial `else if (project === "Agora")`.

## Formats reconnus

- **EPSG** : `EPSG:2100`, `epsg:32634`, ou code numérique nu (`2100`) → normalisé en `EPSG:<n>`.
- **PROJ4** : chaînes commençant par `+proj=`.
- **WKT** : racines `PROJCS[`, `GEOGCS[`, `PROJCRS[`, `GEOGCRS[`, `BOUNDCRS[`, …
- **Named** : noms hérités (`Amarynthos`, `Agora`, `UTM zone 34`, …) résolus via le fallback hardcodé.
- **Inconnu** : warning console + fallback sur le nom de projet si proj4 le connaît.

## Tests

Ajout de 15 tests sur `src/services/__tests__/coordinateUtils.spec.js` : `detectCrsFormat`, `resolveProjectCrs`  et `convertToEPSG4326` end-to-end.
