### PR TITLE
fix(item): show photos of items Stratigraphy/Profile

### DIFF
--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -602,9 +602,8 @@ export default {
         return null; // Retourne null si aucune donnée n'est disponible
       }
 
-      // Filtrer les éléments correspondant à l'UUID
       const filteredItems = trenchData.filter(
-        (x) => x.IdentifierUUID === IdentifierUUID && x.Type === "Image",
+        (x) => x.IdentifierUUID === IdentifierUUID && x.RelationAttachments,
       );
 
       if (filteredItems.length > 0) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,9 @@ export default defineConfig({
       template: { transformAssetUrls },
     }),
     quasar({
-      sassVariables: "src/quasar-variables.sass",
+      sassVariables: fileURLToPath(
+        new URL("./src/quasar-variables.sass", import.meta.url)
+      ),
     }),
   ],
   resolve: {


### PR DESCRIPTION
**Description** :    

**Bug** — [P1-01.4] Les photos attachées aux items de type `Stratigraphy`, `Profile` (et plus largement tout type autre qu'`Image`) ne s'affichaient pas dans le formulaire.

**Cause** : `findObjectByUuid()` dans [TheItem.vue](src/components/TheItem.vue) filtrait sur `x.Type === "Image"`. Or la fonction est appelée avec l'UUID de l'item sélectionné lui-même (cf. boucle `RelationAttachments` ligne 562-573) — items qui peuvent être `Context`, `Stratigraphy`, `Profile`, etc. Le filtre les éliminait donc systématiquement, même quand ils portaient leurs propres `RelationAttachments`.

**Fix** : remplacement de la contrainte de Type par une contrainte de présence d'attachments — `x.RelationAttachments`. L'UUID étant unique, la sélection reste déterministe, et les items "inclus" sans pièces jointes ne génèrent plus de placeholders fantômes (`missing.PNG`).


