### PR TITLE
Add q-chip to TheTable

### DIFF
--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -63,6 +63,7 @@ import { useDataStore } from "@/stores/data";
 import { useAppStore } from "@/stores/app";
 import TheItem from "@/components/TheItem.vue";
 import ThePatches from "@/components/ThePatches.vue";
+import { fieldsSchema } from "@/assets/nativeFields";
 
 import { avrileSansRegularNormal } from "@/assets/AvrileSans-Regular-normal.js";
 import jsPDF from "jspdf";
@@ -77,6 +78,7 @@ export default {
 
   data() {
     return {
+      fieldsSchema: fieldsSchema,
       tabulator: null, //variable to hold table
       tableEditMode: false,
       editedCells: [],
@@ -402,7 +404,9 @@ export default {
     },
 
     getColumnFormatter(fieldName) {
-      if (fieldName === "Type" || fieldName === "Subtype") {
+      if (this.fieldsSchema?.[fieldName]?.type === "link") {
+        return (cell) => this.linkChipsFormatter(cell);
+      } else if (fieldName === "Type" || fieldName === "Subtype") {
         return (cell) => {
           const value = cell.getValue();
           return this.projectPreferencesTypesTranslation[value] ?? value;
@@ -427,6 +431,68 @@ export default {
       }
       // Vous pouvez ajouter d'autres conditions ou retourner undefined pour le cas par défaut
       return undefined;
+    },
+    linkChipsFormatter(cell) {
+      const currentItem = cell.getRow().getData();
+      const container = document.createElement("div");
+      container.className = "table-link-chips";
+
+      this.itemsInChips(cell.getValue(), currentItem).forEach((item) => {
+        const chip = document.createElement("span");
+        chip.className =
+          "q-chip row inline no-wrap items-center q-chip--colored bg-primary text-white q-chip--clickable cursor-pointer table-link-chip";
+        chip.textContent = item.chipText;
+        chip.title = item.chipText;
+
+        chip.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+
+          if (item.fullItem) {
+            this.setSelectedItem(item.fullItem);
+            this.setIsItemSelected(true);
+          }
+        });
+
+        container.appendChild(chip);
+      });
+
+      return container;
+    },
+    itemsInChips(IdentifierUUIDs, currentItem) {
+      if (!IdentifierUUIDs) {
+        return [];
+      }
+
+      return String(IdentifierUUIDs)
+        .split("\n")
+        .filter(Boolean)
+        .map((IdentifierUUID) => this.chipText(IdentifierUUID, currentItem));
+    },
+    chipText(IdentifierUUID, currentItem) {
+      const filteredItems =
+        this.checkedTrenchesData[currentItem.Trench]?.filter((x) =>
+          x.IdentifierUUID.includes(IdentifierUUID),
+        ) ?? [];
+
+      if (filteredItems.length > 0) {
+        const item = filteredItems[0];
+        return {
+          chipText:
+            (this.projectPreferencesTypesTranslation[item.Subtype] ??
+              this.projectPreferencesTypesTranslation[item.Type]) +
+            " " +
+            item.Identifier +
+            " : " +
+            item.Title,
+          fullItem: item,
+        };
+      }
+
+      return {
+        chipText: "Unknown Item",
+        fullItem: null,
+      };
     },
     getColumnFormatterParams(fieldName) {
       if (
@@ -497,5 +563,21 @@ export default {
 }
 .TheItemframe:hover {
   background: rgba(0, 0, 0, 0.5);
+}
+
+:deep(.table-link-chips) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+:deep(.table-link-chip) {
+  max-width: 240px;
+  min-height: 24px;
+  margin: 1px;
+  padding: 0 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/237`

**Description** :    
This pull request enhances the way "link" type fields are displayed in the `TheTable` component by introducing custom chip-style formatting for these fields. It also introduces supporting logic and styles to improve the user experience when interacting with linked items.

**Improvements to "link" field display:**

- Added logic to detect fields of type `"link"` using the imported `fieldsSchema` and apply a new chip-based formatter to these columns. [[1]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aR66) [[2]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aR81) [[3]](diffhunk://#diff-350d67f884edbe3fcb2a11190a4940754ebcd9c5c7d519693978477a88272b3aL405-R409)
- Implemented the `linkChipsFormatter`, `itemsInChips`, and `chipText` methods to render related items as clickable chips in the table. Clicking a chip selects the corresponding item.

**Styling enhancements:**

- Added CSS to style the link chips, ensuring they are visually distinct, wrap appropriately, and handle overflow gracefully.
