### PR TITLE
fix(map): snap zoom to 0.25 steps to keep overlays aligned

### DIFF
--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -156,7 +156,7 @@ export default {
         attributionControl: false,
         zoomControl: true,
         zoomDelta: 0.25,
-        zoomSnap: 0,
+        zoomSnap: 0.25,
         zoomAnimation: false,
         fadeAnimation: false,
         markerZoomAnimation: false,


### PR DESCRIPTION
# Issue

https://github.com/esag-swiss/iDig-Webapp/issues/218

# Description

## Analyse
- `L.imageOverlay` reprojette déjà les overlays à chaque zoom (`_reset` branché sur l'événement `zoom`) : les bounds géographiques n'ont pas à être recalculés — la piste initiale « bounds jamais recalculés » ne tient pas.
- La carte utilisait `zoomSnap: 0`, autorisant des niveaux de zoom **fractionnaires arbitraires** (molette). À ces arrêts, un overlay peut se retrouver décalé de quelques pixels de façon intermittente — cohérent avec « pas toujours ».

## Changement
- `zoomSnap: 0` → `zoomSnap: 0.25` dans `TheMap.vue`.
- Zoom fin conservé (crans de 0.25, aligné sur `zoomDelta`), sans arrêts fractionnaires arbitraires.

## Limites
- ⚠️ Bug **non reproduit** sur Amarynthos (ni Agora / Port_Malia). Correctif basé sur une hypothèse, **non validé** contre une reproduction. Voir note reviewer.