### PR TITLE
fix(table): reset column header filters when switching item type

### DIFF
--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -82,6 +82,7 @@ export default {
       tabulator: null, //variable to hold table
       tableEditMode: false,
       editedCells: [],
+      lastSelectedType: null,
     };
   },
 
@@ -260,27 +261,32 @@ export default {
       { deep: true },
     );
 
+    this.lastSelectedType = this.selectedType;
     this.$watch(
       () => this.columnsTabulator,
       (newCols) => {
-        if (this.tabulator) {
-          // setColumns resets header filter UI values; persist and restore them.
-          const headerFilters = this.tabulator.getHeaderFilters?.() ?? [];
-          const headerFilterValues = headerFilters.reduce((acc, filter) => {
-            if (filter?.field) {
-              acc[filter.field] = filter.value;
-            }
-            return acc;
-          }, {});
+        if (!this.tabulator) {
+          return;
+        }
+        const newFields = new Set(newCols.map((column) => column.field));
+        const currentValues = this.currentHeaderFilterValues();
+        const typeChanged = this.lastSelectedType !== this.selectedType;
 
-          this.tabulator.setColumns(newCols);
+        Object.keys(currentValues).forEach((field) => {
+          this.tabulator.setHeaderFilterValue(field, "");
+        });
 
-          Object.entries(headerFilterValues).forEach(([field, value]) => {
-            if (value !== undefined && value !== null) {
+        this.tabulator.setColumns(newCols);
+
+        if (!typeChanged) {
+          Object.entries(currentValues).forEach(([field, value]) => {
+            if (newFields.has(field) && value !== undefined && value !== null) {
               this.tabulator.setHeaderFilterValue(field, value);
             }
           });
         }
+
+        this.lastSelectedType = this.selectedType;
       },
     );
 
@@ -339,6 +345,15 @@ export default {
       }).href;
 
       window.open(link, "_blank");
+    },
+    currentHeaderFilterValues() {
+      const headerFilters = this.tabulator.getHeaderFilters?.() ?? [];
+      return headerFilters.reduce((acc, filter) => {
+        if (filter?.field) {
+          acc[filter.field] = filter.value;
+        }
+        return acc;
+      }, {});
     },
     printTable() {
       this.tabulator.print(false, true);


### PR DESCRIPTION
# Issue

https://github.com/esag-swiss/iDig-Webapp/issues/219

# Description

## Contexte

Retour client : en filtrant une colonne (ex. Type *Objets*, champ *Catégorie*,
filtre *Container*) puis en changeant de Type de données, la clé de filtre restait
active. Comme le nouveau type (ex. *Contextes*) n'a pas ce champ, **plus aucune
donnée ne s'affichait**.

À noter : le symptôme initial du ticket P1-01.2 (« recherche + tri non
cumulables ») n'était **pas reproductible** — vérifié empiriquement sur Tabulator
6.3.1 et 6.4.0, `replaceData` préserve tri et filtres. Cette MR corrige le vrai
problème remonté ensuite : la persistance des header-filters au changement de type.

## Cause

Le watcher `columnsTabulator` de `TheTable.vue` ré-appliquait les valeurs de
header-filter après `setColumns`, y compris sur un champ absent du nouveau type.
Le filtre restait alors actif sur une colonne inexistante → 0 ligne. Rien ne
réinitialisait les header-filters lors d'un changement de `selectedType`.

## Correctif

- **Réinitialisation des header-filters au changement de Type** (détecté via
  `lastSelectedType`) : effacement avant `setColumns`, sans restauration.
- Comportement **intra-type inchangé** (toggle de visibilité d'un champ) : les
  filtres des colonnes encore présentes sont préservés.

La sauvegarde/restauration des filtres par type (« garder en mémoire au retour sur
le type ») est **volontairement hors périmètre** ici — à traiter dans une demande
dédiée si le besoin est confirmé.

## Tests

- `npm run lint` : OK
- `npm run test:unit` : 45/45 OK
- Reproduction + validation empiriques (Chrome headless + banc Tabulator 6.4) :
  Objets/Catégorie=Container → switch Contextes affiche bien les données ;
  toggle de champ intra-type conserve les filtres.