### PR TITLE
240 adding editing coordinates in theitem

### DIFF
--- a/src/assets/nativeFields.js
+++ b/src/assets/nativeFields.js
@@ -87,7 +87,7 @@ export const fieldsSchema = {
   },
   Subtype: {
     field: "subtype",
-    group: "General",
+    group: "General Section",
     type: "ExtraFields",
     labels: {
       en: "Subtype",
@@ -365,7 +365,7 @@ export const fieldsSchema = {
     },
   },
 
-  // "group": "Relationships",
+  // "group": "Relation Section",
   RelationBelongsToUUID: {
     labels: {
       fr: "appartient à",
@@ -375,7 +375,7 @@ export const fieldsSchema = {
       el: "ανήκει σε",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationCutsUUID: {
     labels: {
@@ -386,7 +386,7 @@ export const fieldsSchema = {
       el: "κόβει",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIncludesUUID: {
     labels: {
@@ -397,7 +397,7 @@ export const fieldsSchema = {
       el: "περιλαμβάνει",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsAboveUUID: {
     labels: {
@@ -408,7 +408,7 @@ export const fieldsSchema = {
       el: "βρίσκεται πάνω",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsBeforeUUID: {
     labels: {
@@ -419,7 +419,7 @@ export const fieldsSchema = {
       el: "είναι πριν",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsBelowUUID: {
     labels: {
@@ -430,7 +430,7 @@ export const fieldsSchema = {
       el: "βρίσκεται κάτω",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsCoevalWithUUID: {
     labels: {
@@ -441,7 +441,7 @@ export const fieldsSchema = {
       el: "είναι σύγχρονος με",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsCutByUUID: {
     labels: {
@@ -452,7 +452,7 @@ export const fieldsSchema = {
       el: "κόβεται από",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsNextToUUID: {
     labels: {
@@ -463,7 +463,7 @@ export const fieldsSchema = {
       el: "είναι δίπλα σε",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   RelationIsAfterUUID: {
     labels: {
@@ -474,7 +474,7 @@ export const fieldsSchema = {
       el: "είναι μετά",
     },
     type: "link",
-    group: "Relationships",
+    group: "Relation Section",
   },
   // COVERAGE TEMPORAL DATE
   CoverageUTC: {
@@ -546,7 +546,6 @@ export const fieldsSchema = {
   CoverageTemporal: {
     type: "Date?",
     field: "CoverageTemporal/Temporal",
-    typeiDig: "ExtraFields",
     labels: {
       en: "coverage temporelle",
       fr: "couverture temporelle",
@@ -594,17 +593,18 @@ export const fieldsSchema = {
   },
 
   // COVERAGE SPATIAL
-  // TODO indentify those that are generated during iPad export
   CoverageSerialized: {
     field: "CoverageSerialized",
+    group: "Points",
     labels: {
       en: "spatial point data",
       fr: "Données topo iDig",
     },
     tips: {
-      en: "raw spatial point data (including fields set by the total station)",
-      fr: "Données ponctuelles spatiales brutes (incluant les champs définis par la station totale)",
+      en: "raw spatial point data (including fields set by the total station) in iDig format",
+      fr: "Données ponctuelles spatiales brutes (incluant les champs définis par la station totale) au format iDig",
     },
+    comment: "Each point is a key=value block separated by blank lines. Coordinates are x, y, z as C-style hexadecimal floats, e.g. 0X1.66D1P+16. Common metadata keys are d date, n point/coverage label, tp=YES, re=YES, sometimes ae=YES. Station-total style points often include p=<point id> and sometimes h=<height>, e.g. p=S28_0419. Multi-surface values use triple newlines, often with labels like OK / UK, haut / bas.",
   },
 
   //  “convenience” fields generated from the “source of truth” inside CoverageSerialized.

--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -190,6 +190,7 @@
               class="col-12 p-1"
               :field="field"
               :current-item="selectedItem"
+              :edit-mode="editMode"
             />
             <!-- BOOLEAN -->
             <TheItemBoolean

--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -115,7 +115,7 @@
       <!--   LISTE OF GROUPS and FIELDS section) -->
       <ul
         v-for="(group, indexGroup) in editMode
-          ? groupOfFieldsAccordingToTypeAndNative
+          ? groupOfFieldsAccordingToType
           : groupsOfFieldsAccordingToItem"
         :key="group"
         class="list-group"
@@ -272,7 +272,10 @@
         <li
           class="list-group-item text-uppercase accordion p-1 pl-2 border-bottom"
         >
-          Fields not included in groups
+          Extra fields
+          <q-tooltip class="bg-accent"
+            >Fields not included in groups section, these fields are not included in any group in the project preferences, but they are present in the current item. They are displayed here for information purposes only.
+          </q-tooltip>
         </li>
         <!-- ROWS -->
         <div
@@ -390,77 +393,6 @@ export default {
       return Object.getOwnPropertyNames(this.selectedItem);
     },
 
-    groupOfFieldsAccordingToTypeAndNative() {
-      // all groups according to type from Preferences + natives fields or groups
-      let groups = [...this.groupOfFieldsAccordingToType];
-      groups.forEach((obj) => {
-        if (obj.group === "General Section") {
-          let fieldsToAdd = [{ field: "Subtype" }];
-          fieldsToAdd.forEach((field) => {
-            if (
-              !obj.fields.some(
-                (existingField) => existingField.field === field.field,
-              )
-            ) {
-              obj.fields.push(field);
-            }
-          });
-        }
-        if (obj.group === "Relation Section") {
-          let fieldsToAdd = [
-            { field: "RelationIsAboveUUID" },
-            { field: "RelationIsBelowUUID" },
-            { field: "RelationIsNextToUUID" },
-            { field: "RelationCutsUUID" },
-            { field: "RelationIsCutByUUID" },
-            { field: "RelationIsAfterUUID" },
-            { field: "RelationIsBeforeUUID" },
-            { field: "RelationIsCoevalWithUUID" },
-            { field: "RelationBelongsToUUID" },
-            { field: "RelationIncludesUUID" },
-          ];
-          fieldsToAdd.forEach((field) => {
-            if (
-              !obj.fields.some(
-                (existingField) => existingField.field === field.field,
-              )
-            ) {
-              obj.fields.push(field);
-            }
-          });
-        }
-        if (obj.group === "Points") {
-          let fieldsToAdd = [{ field: "CoverageSerialized" }];
-          fieldsToAdd.forEach((field) => {
-            if (
-              !obj.fields.some(
-                (existingField) => existingField.field === field.field,
-              )
-            ) {
-              obj.fields.push(field);
-            }
-          });
-        }
-        if (obj.group === "Status Section") {
-          let fieldsToAdd = [
-            { field: "RightsSidelined" },
-            { field: "RightsLocked" },
-            { field: "RightsStatus" },
-          ];
-          fieldsToAdd.forEach((field) => {
-            if (
-              !obj.fields.some(
-                (existingField) => existingField.field === field.field,
-              )
-            ) {
-              obj.fields.push(field);
-            }
-          });
-        }
-      });
-      return groups;
-    },
-
     groupOfFieldsAccordingToType() {
       // all groups according to type from Preferences, include subtype if exists, otherwise type
       const bySubtype = this.projectPreferencesTypes.find((x) => {
@@ -480,14 +412,53 @@ export default {
       });
 
       const typeObj = bySubtype || byType;
-      const groups = typeObj ? typeObj.groups : [];
+
+      // Start from the groups configured in the project preferences for the
+      // selected subtype/type. Each group is cloned so this computed value can
+      // safely add fields without mutating the original preferences object.
+      // The fields array is also cloned because it is enriched below.
+      const groups = typeObj
+        ? typeObj.groups.map((group) => ({
+            ...group,
+            fields: [...(group.fields || [])],
+          }))
+        : [];
+
+      // Ensure every field declared in fieldsSchema and assigned to a group is
+      // present in the group list. Preferences may define the expected group
+      // order/content, while fieldsSchema is the source of truth for available
+      // fields and their metadata.
+      Object.entries(this.fieldsSchema).forEach(([fieldName, fieldSchema]) => {
+        // Fields without a group are intentionally ignored here: this method
+        // only prepares grouped fields for display.
+        if (!fieldSchema?.group) {
+          return;
+        }
+
+        // Reuse an existing group when preferences already define it. If the
+        // schema references a group missing from preferences, create it so the
+        // field remains visible instead of being dropped.
+        let group = groups.find((obj) => obj.group === fieldSchema.group);
+        if (!group) {
+          group = { group: fieldSchema.group, fields: [] };
+          groups.push(group);
+        }
+
+        // Avoid duplicating fields already listed by preferences. When a field
+        // is missing, append its schema metadata and add the field name because
+        // the schema object itself is keyed by name and does not contain it.
+        if (!group.fields.some((field) => field.field === fieldName)) {
+          group.fields.push({ ...fieldSchema, field: fieldName });
+        }
+      });
+
       // except Attachments since photos are managed elsewhere
       return groups.filter((obj) => obj.group !== "Attachments");
     },
 
     groupsOfFieldsAccordingToItem() {
       // used to display only groups where items has fields
-      let groups = this.groupOfFieldsAccordingToTypeAndNative;
+      let groups = this.groupOfFieldsAccordingToType;
       groups = groups.filter((obj) =>
         obj.fields.some((field) =>
           this.fieldsOfCurrentItem.includes(field.field),
@@ -500,13 +471,14 @@ export default {
       let notToDisplay = [
         // "IdentifierUUID",
         "Trench",
+        "RightsLocked",
         "RightsTrashed",
         "RightsDeleted",
         "DateTimeZone",
       ];
       let fieldsNotPrinsentInGroup = [];
 
-      this.groupOfFieldsAccordingToTypeAndNative.forEach((obj) => {
+      this.groupOfFieldsAccordingToType.forEach((obj) => {
         obj.fields.forEach((key) => {
           notToDisplay.push(key.field);
         });

--- a/src/components/TheItemCoverageSerialezed.vue
+++ b/src/components/TheItemCoverageSerialezed.vue
@@ -1,15 +1,22 @@
 <template>
   <div class="col-12 p-1">
     <q-input
-    v-if="editMode"
-    v-model="currentItem[field.field]"
-    square
-    filled
-    dense
-    :clearable="currentItem[field.field] !== previousValue"
-    :label="previousValue !== currentItem[field.field] ? previousValue : ''"
-    @clear="currentItem[field.field] = previousValue"
-  />
+      v-if="editMode"
+      v-model="coordinateText"
+      type="textarea"
+      autogrow
+      square
+      filled
+      dense
+      clearable
+      class="coverage-editor"
+      :label="editLabel"
+      :error="Boolean(parseError)"
+      :error-message="parseError"
+      placeholder="P1 100.000 200.000 12.345"
+      @update:model-value="updateCoverageSerialized"
+      @clear="clearCoverageSerialized"
+    />
     <div v-else>
       {{ determineTypeGeo(currentItem[field.field]) }}
     </div>
@@ -17,7 +24,14 @@
 </template>
 
 <script>
+import { mapState } from "pinia";
 import { determineGeoType } from "@/services/json2geojson";
+import {
+  coverageSerializedToProjectText,
+  projectTextToCoverageSerialized,
+} from "@/services/coverageSerialized";
+import { useDataStore } from "@/stores/data";
+
 export default {
   name: "TheItemCoverageSerialezed",
   props: {
@@ -34,18 +48,89 @@ export default {
       default: false,
     },
   },
+  data() {
+    return {
+      coordinateText: "",
+      parseError: "",
+      isApplyingText: false,
+      coverageTemplate: "",
+    };
+  },
+  computed: {
+    ...mapState(useDataStore, ["projectPreferencesCRS"]),
+
+    coverageSerialized() {
+      return this.currentItem[this.field.field] || "";
+    },
+
+    editLabel() {
+      return `Coordonnees (${this.projectPreferencesCRS || "CRS projet"})`;
+    },
+  },
+  watch: {
+    editMode: {
+      immediate: true,
+      handler(isEditing) {
+        if (isEditing) {
+          this.resetCoordinateText();
+        }
+      },
+    },
+
+    coverageSerialized() {
+      if (this.isApplyingText) {
+        this.isApplyingText = false;
+        return;
+      }
+
+      this.resetCoordinateText();
+    },
+  },
   methods: {
     determineTypeGeo(e) {
       if (e) {
         return determineGeoType(e);
-      } else {
-        return null;
       }
+      return null;
+    },
+
+    resetCoordinateText() {
+      this.coverageTemplate = this.coverageSerialized;
+      this.coordinateText = coverageSerializedToProjectText(
+        this.coverageSerialized,
+      );
+      this.parseError = "";
+    },
+
+    updateCoverageSerialized(value) {
+      const result = projectTextToCoverageSerialized(
+        value,
+        this.coverageTemplate,
+      );
+
+      if (!result.ok) {
+        this.parseError = result.error;
+        return;
+      }
+
+      this.parseError = "";
+      this.isApplyingText = true;
+      this.currentItem[this.field.field] = result.value;
+    },
+
+    clearCoverageSerialized() {
+      this.coordinateText = "";
+      this.parseError = "";
+      this.coverageTemplate = "";
+      this.isApplyingText = true;
+      this.currentItem[this.field.field] = "";
     },
   },
 };
 </script>
 
 <style scoped>
-/* Styles spécifiques au composant enfant */
+.coverage-editor :deep(textarea) {
+  font-family: monospace;
+}
 </style>

--- a/src/components/TheItemCoverageSerialezed.vue
+++ b/src/components/TheItemCoverageSerialezed.vue
@@ -1,6 +1,16 @@
 <template>
   <div class="col-12 p-1">
-    <div>
+    <q-input
+    v-if="editMode"
+    v-model="currentItem[field.field]"
+    square
+    filled
+    dense
+    :clearable="currentItem[field.field] !== previousValue"
+    :label="previousValue !== currentItem[field.field] ? previousValue : ''"
+    @clear="currentItem[field.field] = previousValue"
+  />
+    <div v-else>
       {{ determineTypeGeo(currentItem[field.field]) }}
     </div>
   </div>
@@ -11,8 +21,18 @@ import { determineGeoType } from "@/services/json2geojson";
 export default {
   name: "TheItemCoverageSerialezed",
   props: {
-    field: Object,
-    currentItem: Object,
+    field: {
+      type: Object,
+      required: true,
+    },
+    currentItem: {
+      type: Object,
+      required: true,
+    },
+    editMode: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     determineTypeGeo(e) {

--- a/src/services/__tests__/coordinateUtils.spec.js
+++ b/src/services/__tests__/coordinateUtils.spec.js
@@ -10,31 +10,34 @@ import {
 describe("detectCrsFormat", () => {
   it("should recognise EPSG codes with and without prefix", () => {
     expect(detectCrsFormat("EPSG:2100")).toBe(CRS_FORMAT.EPSG);
+    expect(detectCrsFormat("EPSG2100")).toBe(CRS_FORMAT.EPSG);
+    expect(detectCrsFormat("EPSG2100 GGR87")).toBe(CRS_FORMAT.EPSG);
     expect(detectCrsFormat("epsg:32634")).toBe(CRS_FORMAT.EPSG);
     expect(detectCrsFormat("2100")).toBe(CRS_FORMAT.EPSG);
   });
 
   it("should recognise PROJ4 strings", () => {
     expect(
-      detectCrsFormat("+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000")
+      detectCrsFormat("+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000"),
     ).toBe(CRS_FORMAT.PROJ4);
     expect(detectCrsFormat("  +proj=longlat +datum=WGS84 +no_defs")).toBe(
-      CRS_FORMAT.PROJ4
+      CRS_FORMAT.PROJ4,
     );
   });
 
   it("should recognise WKT strings", () => {
     expect(
-      detectCrsFormat('PROJCS["GGRS87 / Greek Grid",GEOGCS["GGRS87",...]]')
+      detectCrsFormat('PROJCS["GGRS87 / Greek Grid",GEOGCS["GGRS87",...]]'),
     ).toBe(CRS_FORMAT.WKT);
     expect(detectCrsFormat('GEOGCRS["WGS 84",DATUM["WGS_1984",...]]')).toBe(
-      CRS_FORMAT.WKT
+      CRS_FORMAT.WKT,
     );
   });
 
   it("should recognise hardcoded named CRS", () => {
     expect(detectCrsFormat("Amarynthos")).toBe(CRS_FORMAT.NAMED);
     expect(detectCrsFormat("Agora")).toBe(CRS_FORMAT.NAMED);
+    expect(detectCrsFormat("GGR87")).toBe(CRS_FORMAT.NAMED);
     expect(detectCrsFormat("UTM zone 34")).toBe(CRS_FORMAT.NAMED);
   });
 
@@ -63,6 +66,8 @@ describe("resolveProjectCrs", () => {
 
   it("should normalise EPSG codes and accept bare numeric codes", () => {
     expect(resolveProjectCrs("epsg:2100", "Amarynthos")).toBe("EPSG:2100");
+    expect(resolveProjectCrs("EPSG2100", "Port_Malia")).toBe("EPSG:2100");
+    expect(resolveProjectCrs("EPSG2100 GGR87", "Port_Malia")).toBe("EPSG:2100");
     expect(resolveProjectCrs("2100", "Amarynthos")).toBe("EPSG:2100");
   });
 
@@ -73,7 +78,7 @@ describe("resolveProjectCrs", () => {
   it("should register PROJ4 strings dynamically and return a stable key", () => {
     const key = resolveProjectCrs(
       "+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000 +y_0=0 +datum=GGRS87 +units=m +no_defs",
-      "MyCustomProject"
+      "MyCustomProject",
     );
     expect(key).toBe("MyCustomProject__fromPreferences");
     expect(proj4.defs(key)).toBeTruthy();
@@ -111,7 +116,7 @@ describe("convertToEPSG4326", () => {
   it("should work after dynamic registration of a PROJ4 string", () => {
     const key = resolveProjectCrs(
       "+proj=utm +zone=34 +datum=WGS84 +units=m +no_defs",
-      "DynamicUtm"
+      "DynamicUtm",
     );
     const { coords } = convertToEPSG4326([500000, 4000000], key);
     expect(coords.every(Number.isFinite)).toBe(true);

--- a/src/services/__tests__/coverageSerialized.spec.js
+++ b/src/services/__tests__/coverageSerialized.spec.js
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  coverageSerializedToProjectText,
+  decimalToHexFloat,
+  hexFloatToDecimal,
+  projectTextToCoverageSerialized,
+} from "@/services/coverageSerialized";
+
+describe("coverageSerialized coordinate formatting", () => {
+  it("round-trips decimal coordinates through iDig hexadecimal floats", () => {
+    const values = [0, 123.456, -12.5, 421315.789];
+
+    values.forEach((value) => {
+      expect(hexFloatToDecimal(decimalToHexFloat(value))).toBeCloseTo(
+        value,
+        10,
+      );
+    });
+  });
+
+  it("formats CoverageSerialized as project CRS coordinate rows", () => {
+    const coverageSerialized = [
+      `x=${decimalToHexFloat(100)}`,
+      `y=${decimalToHexFloat(200.5)}`,
+      `z=${decimalToHexFloat(12.345)}`,
+      "",
+      `x=${decimalToHexFloat(101)}`,
+      `y=${decimalToHexFloat(201.5)}`,
+      `z=${decimalToHexFloat(13.345)}`,
+    ].join("\n");
+
+    expect(coverageSerializedToProjectText(coverageSerialized)).toBe(
+      "100\t200.5\t12.345\n101\t201.5\t13.345",
+    );
+  });
+
+  it("keeps the station point id visible when CoverageSerialized has p", () => {
+    const coverageSerialized = [
+      "d=2021-08-06T06:29:32Z",
+      "n=find-spot",
+      `x=${decimalToHexFloat(100)}`,
+      `y=${decimalToHexFloat(200)}`,
+      `z=${decimalToHexFloat(12.3)}`,
+      "h=0X1.4CCCCCCCCCCCDP+0",
+      "re=YES",
+      "p=S28_0419",
+    ].join("\n");
+
+    expect(coverageSerializedToProjectText(coverageSerialized)).toBe(
+      "S28_0419\t100\t200\t12.3",
+    );
+  });
+});
+
+describe("projectTextToCoverageSerialized", () => {
+  it("accepts one XYZ coordinate row per line", () => {
+    const result = projectTextToCoverageSerialized(
+      "100 200 12.3\n101 201 12.4",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(coverageSerializedToProjectText(result.value)).toBe(
+      "100\t200\t12.3\n101\t201\t12.4",
+    );
+  });
+
+  it("uses the last three numeric columns for station exports with point ids", () => {
+    const result = projectTextToCoverageSerialized(
+      "P1 100.1 200.2 12.3\nP2 101.1 201.2 12.4",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(coverageSerializedToProjectText(result.value)).toBe(
+      "100.1\t200.2\t12.3\n101.1\t201.2\t12.4",
+    );
+  });
+
+  it("accepts semicolon-separated rows with decimal commas", () => {
+    const result = projectTextToCoverageSerialized("P1;100,1;200,2;12,3");
+
+    expect(result.ok).toBe(true);
+    expect(coverageSerializedToProjectText(result.value)).toBe(
+      "100.1\t200.2\t12.3",
+    );
+  });
+
+  it("uses X/Y/Z headers when present", () => {
+    const result = projectTextToCoverageSerialized(
+      "code;Y;X;Z\nP1;200;100;12.3",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(coverageSerializedToProjectText(result.value)).toBe(
+      "100\t200\t12.3",
+    );
+  });
+
+  it("returns a validation error for unrecognized rows", () => {
+    const result = projectTextToCoverageSerialized("P1 north east high");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Ligne 1");
+  });
+
+  it("preserves existing iDig metadata while replacing coordinates", () => {
+    const previous = [
+      "d=2021-08-06T06:29:32Z",
+      "n=find-spot",
+      `x=${decimalToHexFloat(100)}`,
+      `y=${decimalToHexFloat(200)}`,
+      `z=${decimalToHexFloat(12.3)}`,
+      "h=0X1.4CCCCCCCCCCCDP+0",
+      "re=YES",
+      "p=S28_0419",
+    ].join("\n");
+    const result = projectTextToCoverageSerialized(
+      "S28_9999 101 201 13.4",
+      previous,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.value).toContain("d=2021-08-06T06:29:32Z");
+    expect(result.value).toContain("n=find-spot");
+    expect(result.value).toContain("h=0X1.4CCCCCCCCCCCDP+0");
+    expect(result.value).toContain("re=YES");
+    expect(result.value).toContain("p=S28_9999");
+    expect(coverageSerializedToProjectText(result.value)).toBe(
+      "S28_9999\t101\t201\t13.4",
+    );
+  });
+
+  it("creates iDig-style point blocks for new pasted coordinates", () => {
+    const result = projectTextToCoverageSerialized("P1 100 200 12.3", "");
+
+    expect(result.ok).toBe(true);
+    expect(result.value).toContain("d=");
+    expect(result.value).toContain("n=point");
+    expect(result.value).toContain("p=P1");
+    expect(result.value).toContain("tp=YES");
+    expect(result.value).toContain("re=YES");
+  });
+});

--- a/src/services/coordinateUtils.js
+++ b/src/services/coordinateUtils.js
@@ -11,6 +11,10 @@ proj4.defs([
     "+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000 +y_0=0 +datum=GGRS87 +units=m +no_defs ",
   ],
   [
+    "GGR87",
+    "+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000 +y_0=0 +datum=GGRS87 +units=m +no_defs ",
+  ],
+  [
     "AEO_Aegina",
     "+proj=tmerc +lat_0=0 +lon_0=24 +k=0.9996 +x_0=500000 +y_0=0 +datum=GGRS87 +units=m +no_defs ",
   ],
@@ -37,6 +41,7 @@ proj4.defs([
 const HARDCODED_CRS_NAMES = new Set([
   "EPSG:2100",
   "GGRS87",
+  "GGR87",
   "AEO_Aegina",
   "Amarynthos",
   "EPSG:4326",
@@ -61,13 +66,16 @@ export const CRS_FORMAT = Object.freeze({
 // ───────────────────────────────────────────────────────────────────────────
 
 const EPSG_WITH_PREFIX_REGEX = /^EPSG:\d+$/i;
+const EPSG_IN_TEXT_REGEX = /\bEPSG\s*:?\s*(\d{4,6})\b/i;
 const EPSG_BARE_NUMERIC_REGEX = /^\d{4,6}$/;
 const PROJ4_PREFIX_REGEX = /^\+proj=/i;
 const WKT_ROOT_KEYWORD_REGEX =
   /^(PROJCS|GEOGCS|PROJCRS|GEOGCRS|GEOCCS|COMPDCS|COMPD_CS|VERT_CS|VERTCRS|BOUNDCRS|ENGCRS|TIMECRS)\s*\[/i;
 
 const isEpsg = (value) =>
-  EPSG_WITH_PREFIX_REGEX.test(value) || EPSG_BARE_NUMERIC_REGEX.test(value);
+  EPSG_WITH_PREFIX_REGEX.test(value) ||
+  EPSG_IN_TEXT_REGEX.test(value) ||
+  EPSG_BARE_NUMERIC_REGEX.test(value);
 const isProj4 = (value) => PROJ4_PREFIX_REGEX.test(value);
 const isWkt = (value) => WKT_ROOT_KEYWORD_REGEX.test(value);
 const isNamedCrs = (value) => HARDCODED_CRS_NAMES.has(value);
@@ -106,7 +114,12 @@ export function detectCrsFormat(crsValue) {
 // ───────────────────────────────────────────────────────────────────────────
 
 function normalizeEpsgCode(value) {
-  const code = EPSG_WITH_PREFIX_REGEX.test(value) ? value.split(":")[1] : value;
+  const match = EPSG_IN_TEXT_REGEX.exec(value);
+  const code = match
+    ? match[1]
+    : EPSG_WITH_PREFIX_REGEX.test(value)
+      ? value.split(":")[1]
+      : value;
   return `EPSG:${code}`;
 }
 

--- a/src/services/coverageSerialized.js
+++ b/src/services/coverageSerialized.js
@@ -1,0 +1,332 @@
+const COORDINATE_KEYS = ["x", "y", "z"];
+const POINT_SEPARATOR = "\n\n";
+
+function utcTimestamp() {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function trimTrailingZeros(value) {
+  return value.replace(/(\.\d*?)0+$/, "$1").replace(/\.$/, "");
+}
+
+function formatProjectNumber(value) {
+  if (!Number.isFinite(value)) {
+    return "";
+  }
+
+  return trimTrailingZeros(Number(value.toPrecision(12)).toString());
+}
+
+export function hexFloatToDecimal(hex) {
+  if (typeof hex !== "string") {
+    return null;
+  }
+
+  const value = hex.trim();
+  const decimal = Number(value);
+  if (Number.isFinite(decimal)) {
+    return decimal;
+  }
+
+  const match =
+    /^([+-]?)0X([0-9A-Fa-f]+)(?:\.([0-9A-Fa-f]*))?P([+-]?\d+)$/i.exec(value);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, integerPart, fractionalPart = "", exponent] = match;
+  let result = parseInt(integerPart, 16);
+
+  for (let i = 0; i < fractionalPart.length; i++) {
+    result += parseInt(fractionalPart[i], 16) * 16 ** -(i + 1);
+  }
+
+  result *= 2 ** Number(exponent);
+  return sign === "-" ? -result : result;
+}
+
+export function decimalToHexFloat(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new TypeError(`Invalid coordinate value: ${value}`);
+  }
+
+  const sign = number < 0 ? "-" : "";
+  const [integerPart, fractionalPart = "0"] = Math.abs(number)
+    .toString(16)
+    .split(".");
+
+  return `${sign}0X${integerPart.toUpperCase()}.${fractionalPart.toUpperCase()}P0`;
+}
+
+function parseCoveragePoint(block) {
+  const point = {};
+
+  block.split(/\r?\n/).forEach((row) => {
+    const [rawKey, rawValue] = row.split("=");
+    const key = rawKey?.trim().toLowerCase();
+
+    if (!COORDINATE_KEYS.includes(key)) {
+      if (key === "p") {
+        point.p = rawValue;
+      }
+      return;
+    }
+
+    const value = hexFloatToDecimal(rawValue);
+    if (value !== null) {
+      point[key] = value;
+    }
+  });
+
+  return point;
+}
+
+export function coverageSerializedToProjectText(coverageSerialized) {
+  if (!coverageSerialized || typeof coverageSerialized !== "string") {
+    return "";
+  }
+
+  return coverageSerialized
+    .split(/\n{2,}/)
+    .map((block) => parseCoveragePoint(block))
+    .filter((point) => point.x !== undefined && point.y !== undefined)
+    .map((point) => {
+      const coordinates = COORDINATE_KEYS.filter(
+        (key) => point[key] !== undefined,
+      )
+        .map((key) => formatProjectNumber(point[key]))
+        .join("\t");
+
+      return point.p ? `${point.p}\t${coordinates}` : coordinates;
+    })
+    .join("\n");
+}
+
+function parseProjectNumber(token) {
+  const cleaned = token?.trim().replace(/^["']|["']$/g, "");
+  if (!cleaned) {
+    return null;
+  }
+
+  const normalized = cleaned.replace(",", ".");
+  if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?$/i.test(normalized)) {
+    return null;
+  }
+
+  const number = Number(normalized);
+  return Number.isFinite(number) ? number : null;
+}
+
+function splitColumns(row) {
+  const trimmed = row.trim();
+
+  if (/[;\t]/.test(trimmed)) {
+    return trimmed.split(/[;\t]+/).map((token) => token.trim());
+  }
+
+  const commaColumns = trimmed.split(/\s*,\s*/);
+  if (commaColumns.length >= 3) {
+    return commaColumns;
+  }
+
+  return trimmed.split(/\s+/);
+}
+
+function headerIndex(columns, candidates) {
+  return columns.findIndex((column) =>
+    candidates.includes(column.trim().toLowerCase()),
+  );
+}
+
+function detectHeader(rows) {
+  if (rows.length < 2) {
+    return null;
+  }
+
+  const columns = splitColumns(rows[0]);
+  const x = headerIndex(columns, ["x", "e", "east", "easting"]);
+  const y = headerIndex(columns, ["y", "n", "north", "northing"]);
+  const z = headerIndex(columns, ["z", "h", "alt", "height", "elevation"]);
+  const p = headerIndex(columns, ["p", "id", "name", "code", "point"]);
+
+  return x !== -1 && y !== -1 ? { p, x, y, z } : null;
+}
+
+function parsePointRow(row, header) {
+  const columns = splitColumns(row);
+
+  if (header) {
+    const x = parseProjectNumber(columns[header.x]);
+    const y = parseProjectNumber(columns[header.y]);
+    const z = header.z === -1 ? null : parseProjectNumber(columns[header.z]);
+    const p = header.p === -1 ? null : columns[header.p]?.trim();
+
+    if (x === null || y === null) {
+      return null;
+    }
+
+    return {
+      p: p || null,
+      values: z === null ? [x, y] : [x, y, z],
+    };
+  }
+
+  const parsedColumns = columns.map((column) => ({
+    raw: column,
+    value: parseProjectNumber(column),
+  }));
+  const numbers = parsedColumns
+    .map((column) => column.value)
+    .filter((number) => number !== null);
+
+  if (numbers.length < 2) {
+    return null;
+  }
+
+  let p = null;
+  if (numbers.length === 2 || numbers.length === 3) {
+    const firstColumn = parsedColumns[0];
+    if (firstColumn.value === null && columns.length > numbers.length) {
+      p = firstColumn.raw;
+    }
+
+    return { p, values: numbers };
+  }
+
+  const firstColumn = parsedColumns[0];
+  if (firstColumn.raw) {
+    p = firstColumn.raw;
+  }
+
+  return { p, values: numbers.slice(-3) };
+}
+
+function splitCoverageBlocks(coverageSerialized) {
+  if (!coverageSerialized || typeof coverageSerialized !== "string") {
+    return [];
+  }
+
+  return coverageSerialized.split(/\r?\n(?:\r?\n)+/).filter(Boolean);
+}
+
+function splitCoverageParts(coverageSerialized) {
+  return {
+    blocks: splitCoverageBlocks(coverageSerialized),
+    separators:
+      typeof coverageSerialized === "string"
+        ? Array.from(
+            coverageSerialized.matchAll(/\r?\n(?:\r?\n)+/g),
+            (match) => match[0],
+          )
+        : [],
+  };
+}
+
+function joinCoverageBlocks(blocks, separators) {
+  return blocks
+    .map((block, index) =>
+      index < blocks.length - 1
+        ? `${block}${separators[index] || POINT_SEPARATOR}`
+        : block,
+    )
+    .join("");
+}
+
+function setBlockValue(lines, key, value) {
+  const index = lines.findIndex((line) => line.startsWith(`${key}=`));
+  const row = `${key}=${value}`;
+
+  if (index === -1) {
+    lines.push(row);
+  } else {
+    lines[index] = row;
+  }
+}
+
+function buildDefaultBlock(point) {
+  const lines = [`d=${utcTimestamp()}`, "n=point"];
+
+  point.values.forEach((value, index) => {
+    lines.push(`${COORDINATE_KEYS[index]}=${decimalToHexFloat(value)}`);
+  });
+
+  if (point.p) {
+    lines.push(`p=${point.p}`);
+  }
+
+  lines.push("tp=YES", "re=YES");
+  return lines.join("\n");
+}
+
+function pointToCoverageBlock(point, templateBlock) {
+  if (!templateBlock) {
+    return buildDefaultBlock(point);
+  }
+
+  const lines = templateBlock.split(/\r?\n/).filter(Boolean);
+
+  point.values.forEach((value, index) => {
+    setBlockValue(lines, COORDINATE_KEYS[index], decimalToHexFloat(value));
+  });
+
+  if (point.p) {
+    setBlockValue(lines, "p", point.p);
+  }
+
+  return lines.join("\n");
+}
+
+function pointToCoordinatesOnlyBlock(point) {
+  return point.values
+    .map(
+      (value, index) => `${COORDINATE_KEYS[index]}=${decimalToHexFloat(value)}`,
+    )
+    .join("\n");
+}
+
+export function projectTextToCoverageSerialized(
+  text,
+  previousCoverageSerialized,
+) {
+  if (!text || !text.trim()) {
+    return { ok: true, value: "" };
+  }
+
+  const rows = text
+    .split(/\r?\n/)
+    .map((row) => row.trim())
+    .filter(Boolean);
+  const header = detectHeader(rows);
+  const pointRows = header ? rows.slice(1) : rows;
+  const points = [];
+  const { blocks: templates, separators } = splitCoverageParts(
+    previousCoverageSerialized,
+  );
+
+  for (let i = 0; i < pointRows.length; i++) {
+    const point = parsePointRow(pointRows[i], header);
+    if (!point) {
+      return {
+        ok: false,
+        error: `Ligne ${header ? i + 2 : i + 1}: coordonnees non reconnues.`,
+      };
+    }
+    points.push(point);
+  }
+
+  const blocks = points.map((point, index) =>
+    previousCoverageSerialized === undefined
+      ? pointToCoordinatesOnlyBlock(point)
+      : pointToCoverageBlock(point, templates[index]),
+  );
+
+  return {
+    ok: true,
+    value:
+      previousCoverageSerialized === undefined
+        ? blocks.join(POINT_SEPARATOR)
+        : joinCoverageBlocks(blocks, separators),
+  };
+}

--- a/src/services/json2geojson.js
+++ b/src/services/json2geojson.js
@@ -1,4 +1,5 @@
 import { convertToEPSG4326 } from "@/services/coordinateUtils";
+import { hexFloatToDecimal } from "@/services/coverageSerialized";
 import { useDataStore } from "@/stores/data";
 
 const LEVEL_2_SEPARATOR = "\n\n";
@@ -151,7 +152,10 @@ export function CoverageSerializedXYZToGeojsonPosition(XYZ) {
     const [key, value] = rawCoordinate.split("=");
 
     if (COORDINATE_PREFIXES.includes(key)) {
-      values.push(hexToDecimal(value));
+      const coordinate = hexFloatToDecimal(value);
+      if (coordinate !== null) {
+        values.push(coordinate);
+      }
     }
 
     return values;
@@ -167,40 +171,6 @@ export function CoverageSerializedXYZToGeojsonPosition(XYZ) {
   }
 
   return coordinates;
-}
-
-function hexToDecimal(hex) {
-  const match = /^0X([0-9A-Fa-f]+).([0-9A-Fa-f]+)P([+-]?\d+)$/i.exec(hex);
-
-  if (match) {
-    const hexadecimal = match[1];
-    const fractionalPart = match[2] || "";
-    const exponent = match[3];
-
-    let decimal = 0;
-    let power = 0;
-
-    for (let i = hexadecimal.length - 1; i >= 0; i--) {
-      const digit = parseInt(hexadecimal[i], 16);
-      decimal += digit * 16 ** power;
-      power++;
-    }
-
-    let fractional = 0;
-    power = -1;
-
-    for (let i = 0; i < fractionalPart.length; i++) {
-      const digit = parseInt(fractionalPart[i], 16);
-      fractional += digit * 16 ** power;
-      power--;
-    }
-
-    decimal += fractional;
-    decimal *= 2 ** exponent;
-
-    return Number(decimal);
-  }
-  return 0;
 }
 
 // to be a valid geojson we need coordinates of polygones to be clockwise


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/240
This pull request add editing of spatial point data (`CoverageSerialized`) and improves native fields schema and allows some TheItem logic to rely on it.

### Field Grouping and Display Improvements

* The logic for grouping fields in `TheItem.vue` now dynamically merges the project preferences with the canonical `fieldsSchema`, ensuring all fields assigned to a group are displayed, even if missing from preferences. This removes the previous manual merging logic and prevents fields from being dropped if not explicitly listed in preferences. (`[[1]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL392-L462)`, `[[2]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL482-R461)`)
* The "Extra fields" section is clarified with a tooltip explaining its purpose: to show fields present in the item but not assigned to any group in preferences. (`[src/components/TheItem.vueL274-R278](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL274-R278)`)

### Field Schema and Metadata Updates

* The `group` property for many relationship fields in `fieldsSchema` is renamed from "Relationships" to "Relation Section" for consistency. The `Subtype` field's group is also updated to "General Section". (`[[1]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL90-R90)`, `[[2]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL368-R368)`, `[[3]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL378-R378)`, `[[4]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL389-R389)`, `[[5]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL400-R400)`, `[[6]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL411-R411)`, `[[7]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL422-R422)`, `[[8]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL433-R433)`, `[[9]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL444-R444)`, `[[10]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL455-R455)`, `[[11]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL466-R466)`, `[[12]](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL477-R477)`)
* The `CoverageSerialized` field now has a group ("Points"), improved tooltips, and a detailed comment describing the format for better maintainability and clarity. (`[src/assets/nativeFields.jsL597-R607](diffhunk://#diff-a9a1746a55ceafa1336ce3b3189d994a87d0efbe5f486b7eb4fcadd8c25c08fdL597-R607)`)

### CoverageSerialized Editing Experience

* The `TheItemCoverageSerialezed.vue` component now provides a textarea editor for spatial point data when in edit mode, with live validation and error messaging. It uses project CRS preferences and supports parsing and serializing between the project text format and the raw storage format. (`[src/components/TheItemCoverageSerialezed.vueL3-R135](diffhunk://#diff-65efa08e57ed68b2f48a4d0379b75ed4f1d73f86c745accab8961516e5feabffL3-R135)`)
* The parent component passes `editMode` to the coverage editor, enabling this improved editing UI. (`[src/components/TheItem.vueR193](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bR193)`)

### CRS Detection and Normalization

* CRS detection now recognizes more EPSG code formats (e.g., "EPSG2100", "EPSG2100 GGR87") and named CRS values, improving flexibility for user input. Tests are updated to cover these cases. (`[[1]](diffhunk://#diff-ebae98bce84ae6362db9f80928f1255d361f37a69e986fde38f6079f2b8d0e7bR13-R40)`, `[[2]](diffhunk://#diff-ebae98bce84ae6362db9f80928f1255d361f37a69e986fde38f6079f2b8d0e7bR69-R70)`, `[[3]](diffhunk://#diff-ebae98bce84ae6362db9f80928f1255d361f37a69e986fde38f6079f2b8d0e7bL76-R81)`, `[[4]](diffhunk://#diff-ebae98bce84ae6362db9f80928f1255d361f37a69e986fde38f6079f2b8d0e7bL114-R119)`)

### Minor Cleanups

* The now-obsolete `groupOfFieldsAccordingToTypeAndNative` method is removed, and all references are updated to use the new, unified grouping logic. (`[[1]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL118-R118)`, `[[2]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bR474-R481)`)

These changes collectively make the item view more robust, extensible, and user-friendly, especially for projects with evolving field schemas and complex spatial data requirements.`

