### PR TITLE
fix(map): preserve selected base layer when toggling trenches

### DIFF
--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -156,7 +156,7 @@ export default {
         attributionControl: false,
         zoomControl: true,
         zoomDelta: 0.25,
-        zoomSnap: 0,
+        zoomSnap: 0.25,
         zoomAnimation: false,
         fadeAnimation: false,
         markerZoomAnimation: false,

--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -43,6 +43,7 @@ export default {
       enableScrollWheelZoom: true,
       wheelDebounceTime: 140,
       wheelPxPerZoomLevel: 180,
+      selectedBaseLayer: null,
     };
   },
   computed: {
@@ -163,7 +164,7 @@ export default {
         scrollWheelZoom: this.enableScrollWheelZoom,
         wheelDebounceTime: this.wheelDebounceTime,
         wheelPxPerZoomLevel: this.wheelPxPerZoomLevel,
-        layers: this.baseLayersTree.children[3].layer,
+        layers: this.selectedBaseLayer ?? this.baseLayersTree.children[3].layer,
       });
 
       // Ajout du control de couches en arborescence
@@ -172,6 +173,10 @@ export default {
         this.overlaysTree,
       );
       this.treeLayerControl.addTo(this.map);
+
+      this.map.on("baselayerchange", (event) => {
+        this.selectedBaseLayer = event.layer;
+      });
 
       // Ajout de l'échelle
       L.control


### PR DESCRIPTION
**Issue** :  https://github.com/esag-swiss/iDig-Webapp/issues/218

**Description** :    

## Contexte
Remonté par le client en marge du ticket #218 : dans la carte, sélectionner/masquer un trench réinitialise le fond de carte précédemment choisi.

## Cause
Le watcher `checkedTrenchesItemsPlans` recrée entièrement la carte (`destroyMap()` + `initMap()`) à chaque changement de trench. `initMap()` créait la carte avec `layers: baseLayersTree.children[3].layer` (Satellite) en dur → le fond choisi par l'utilisateur était perdu. Comportement préexistant, indépendant du fix zoom (#242).

## Changement
- Mémorisation du fond actif via l'événement `baselayerchange`.
- `initMap()` réutilise ce fond (repli sur Satellite au premier chargement).
- Aucune modification du cycle destroy/recreate de la carte (hors scope).

## Test
1. Ouvrir la carte, choisir un fond ≠ Satellite (ex. OSM).
2. Cocher/décocher un trench.
3. ✅ Le fond OSM est conservé (avant : retour à Satellite).
