### PR TITLE
fix(item): merge item drawing with related photos

### DIFF
--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -535,36 +535,25 @@ export default {
     },
 
     async fetchImages() {
-      let relatedItems = [];
+      const relatedItems = [];
+
       if (this.selectedItem?.RelationAttachments) {
-        relatedItems = [this.selectedItem.IdentifierUUID];
-        // Récupérer les URL d'images pour chaque UUID trouvé
-        const imagePromises = relatedItems.map((uuid) =>
-          this.findObjectByUuid(uuid),
-        );
-        // Attendre la résolution de toutes les promesses d'URL d'images
-        const resolvedImages = await Promise.all(imagePromises);
-
-        // Filtrer les résultats pour ne garder que les valeurs non nulles
-        this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
+        relatedItems.push(this.selectedItem.IdentifierUUID);
       }
+
       if (this.selectedItem?.RelationIncludesUUID && this.selectedItem.Trench) {
-        if (this.selectedItem.RelationIncludesUUID.includes("\n")) {
-          relatedItems = this.selectedItem.RelationIncludesUUID.split("\n");
-        } else {
-          relatedItems = [this.selectedItem.RelationIncludesUUID];
-        }
-
-        // Récupérer les URL d'images pour chaque UUID trouvé
-        const imagePromises = relatedItems.map((uuid) =>
-          this.findObjectByUuid(uuid),
-        );
-        // Attendre la résolution de toutes les promesses d'URL d'images
-        const resolvedImages = await Promise.all(imagePromises);
-
-        // Filtrer les résultats pour ne garder que les valeurs non nulles
-        this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
+        relatedItems.push(...this.selectedItem.RelationIncludesUUID.split("\n"));
       }
+
+      if (relatedItems.length === 0) {
+        return;
+      }
+
+      const resolvedImages = await Promise.all(
+        relatedItems.map((uuid) => this.findObjectByUuid(uuid)),
+      );
+
+      this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
     },
 
     findObjectByUuid(IdentifierUUID) {


### PR DESCRIPTION
# Issue

https://github.com/esag-swiss/iDig-Webapp/issues/221

# Description

## Cause

Dans `fetchImages()` (`src/components/TheItem.vue`), les deux sources d'images étaient traitées dans deux blocs séparés qui **assignaient tous les deux** `this.relatedImageUrls` :

1. `RelationAttachments` → le dessin/l'image de l'item lui-même
2. `RelationIncludesUUID` → les photos des items liés

Le second bloc écrasait le résultat du premier. Chaque bloc faisant son propre `await Promise.all(...)`, le dessin s'affichait d'abord puis était supplanté par les photos liées à la résolution de la seconde promesse.

## Correctif

- Collecte des UUID des deux sources dans un unique tableau `relatedItems` (dessin de l'item en premier, puis photos liées).
- Résolution en un seul `Promise.all` et **une seule assignation** de `relatedImageUrls` → plus d'écrasement ni de course asynchrone.

## Tests manuels

Sur la tranchée `AMA24-general` :

- Item `D178` (Strati, dessin + photo liée St416) → dessin **et** photo affichés ensemble, de façon stable ✅
- Item de type `Plan` (dessin, sans photo liée) → non-régression, dessin toujours affiché ✅
- Item de type `Image` seul → photo affichée comme avant ✅