### PR TITLE
feat(map-export): render raster at 3x resolution for sharper SVG export

### DIFF
--- a/src/services/mapExport.js
+++ b/src/services/mapExport.js
@@ -1,5 +1,7 @@
 import html2canvas from "html2canvas";
 
+const EXPORT_RASTER_SCALE = 3;
+
 export function exportMapAsPNG() {
   const mapElement = document.getElementById("mapContainer");
   // Utiliser html2canvas pour capturer l'élément de la carte
@@ -47,6 +49,7 @@ export async function exportMapAsCompositeSVG() {
     },
     useCORS: true,
     async: true,
+    scale: EXPORT_RASTER_SCALE,
   });
   const imgData = canvas.toDataURL("image/png");
 

--- a/src/services/mapExport.js
+++ b/src/services/mapExport.js
@@ -51,21 +51,33 @@ export async function exportMapAsCompositeSVG() {
   const imgData = canvas.toDataURL("image/png");
 
   // 2. Prépare le SVG vectoriel
-  const svgClone = svgLayer.cloneNode(true);
-  // Récupère la taille du conteneur
   const width = mapElement.offsetWidth;
   const height = mapElement.offsetHeight;
 
-  // 3. Crée un SVG composite
+  const svgRect = svgLayer.getBoundingClientRect();
+  const mapRect = mapElement.getBoundingClientRect();
+  const offsetX = svgRect.left - mapRect.left;
+  const offsetY = svgRect.top - mapRect.top;
+  const viewBoxAttr = svgLayer.getAttribute("viewBox");
+  const [viewBoxX, viewBoxY] = viewBoxAttr
+    ? viewBoxAttr.split(/\s+/).map(Number)
+    : [0, 0];
+  const translateX = offsetX - (viewBoxX || 0);
+  const translateY = offsetY - (viewBoxY || 0);
+
+  const svgClone = svgLayer.cloneNode(true);
   const serializer = new XMLSerializer();
-  const svgContent = serializer.serializeToString(svgClone);
-  // Reconstruis le SVG pour Illustrator en ajoutant le namespace xlink et en passant à xlink:href
+  const innerContent = Array.from(svgClone.childNodes)
+    .map((node) => serializer.serializeToString(node))
+    .join("");
+
+  // 3. Crée un SVG composite
   const compositeSVG = `<?xml version="1.0" encoding="UTF-8"?>
   <svg xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
     width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
     <image xlink:href="${imgData}" x="0" y="0" width="${width}" height="${height}"/>
-    ${svgContent}
+    <g transform="translate(${translateX} ${translateY})">${innerContent}</g>
   </svg>`;
   // 4. Télécharge le SVG composite
   const blob = new Blob([compositeSVG], { type: "image/svg+xml" });


### PR DESCRIPTION
# Issue

https://github.com/esag-swiss/iDig-Webapp/issues/222

# Description

## Contexte

Deux améliorations sur l'export SVG composite de la carte (`src/services/mapExport.js`), déclenché par le bouton *download* de la carte.

## 1. Alignement raster / symboles (bug)

**Problème** — L'export s'ouvrait correctement dans Edge, mais présentait un
décalage entre le fond raster (PNG) et la couche symboles (SVG) dans les autres
renderers (Chrome en ouverture directe, Firefox) et surtout dans les
applications (Inkscape, Illustrator, Affinity, Word).

**Cause** — Leaflet positionne la couche SVG via des `transform: translate3d(...)`
CSS (sur le `<svg>` et son parent `.leaflet-overlay-pane`). Ces transforms CSS
ne sont pas honorés par les renderers SVG standalone hors Edge.

**Correctif** — On ne sérialise plus le `<svg>` externe porteur du transform CSS.
On lit la position effective de la couche via `getBoundingClientRect` et on la
réinjecte en `transform="translate(...)"` SVG **natif**, sur un `<g>` enveloppant
le contenu cloné — en tenant compte d'une éventuelle origine de `viewBox` non nulle.

## 2. Résolution du fond raster (amélioration)

**Problème** — Le fond raster était exporté à la résolution d'affichage écran,
ce qui dégradait le détail des plans de fouille (images sources haute résolution
affichées réduites).

**Correctif** — On passe `scale: 3` à `html2canvas` : le raster est rendu à 3× la
résolution écran avant d'être embarqué. L'`<image>` conserve ses dimensions CSS,
donc l'alignement et la taille du SVG sont inchangés.

> ⚠️ À `scale: 3`, le canvas couvre 9× les pixels. Sur de très grandes cartes, la
> limite navigateur (~16 k px de côté) peut être atteinte → à surveiller, un clamp
> dynamique du scale reste possible en suivi.

## Scénario de test

1. Ouvrir une carte avec des items géolocalisés **et** un plan raster.
2. Paner / zoomer pour créer un offset de la couche SVG.
3. Exporter via le bouton *download* → `map_composite_export.svg`.
4. Ouvrir le fichier dans **Firefox** *et* dans **Inkscape / Illustrator** :
   - raster et symboles alignés dans tous les cas ;
   - plan raster net (pas de flou d'affichage écran).

## Fichier concerné

- `src/services/mapExport.js`