### PR TITLE
feat(filter): add relational filtering engine

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
           <TheControlSearch></TheControlSearch>
           <TheControlTrenches></TheControlTrenches>
           <TheControlFields></TheControlFields>
+          <TheControlRelationFilter></TheControlRelationFilter>
           <TheControlExport></TheControlExport>
         </div>
       </nav>
@@ -82,6 +83,7 @@ import TheHeader from "@/components/TheHeader.vue";
 import TheControlSearch from "@/components/TheControlSearch.vue";
 import TheControlTrenches from "@/components/TheControlTrenches.vue";
 import TheControlFields from "@/components/TheControlFields.vue";
+import TheControlRelationFilter from "@/components/TheControlRelationFilter.vue";
 import TheControlExport from "@/components/TheControlExport.vue";
 import TheTable from "@/components/TheTable.vue";
 import TheSpinner from "@/components/TheSpinner.vue";
@@ -98,6 +100,7 @@ export default {
     TheControlSearch,
     TheControlTrenches,
     TheControlFields,
+    TheControlRelationFilter,
     TheControlExport,
     TheTable,
     TheMap,

--- a/src/components/TheControlRelationFilter.vue
+++ b/src/components/TheControlRelationFilter.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="p-1 m-1 border-0">
+    <h3>{{ $t("app.relation_filter_title") }}</h3>
+    <q-tooltip class="bg-accent">{{ $t("app.relation_filter_tip") }}</q-tooltip>
+  </div>
+  <select
+    v-model="relation"
+    class="form-control form-control-sm mb-1"
+    @change="emitFilter"
+  >
+    <option value="">{{ $t("app.relation_filter_relation") }}</option>
+    <option v-for="field in relationFields" :key="field" :value="field">
+      {{ relationLabel(field) }}
+    </option>
+  </select>
+  <select
+    v-model="property"
+    class="form-control form-control-sm mb-1"
+    @change="emitFilter"
+  >
+    <option value="">{{ $t("app.relation_filter_property") }}</option>
+    <option
+      v-for="(label, key) in projectPreferencesFieldsWithTranslation"
+      :key="key"
+      :value="key"
+    >
+      {{ label || key }}
+    </option>
+  </select>
+  <q-input
+    v-model="value"
+    square
+    filled
+    dense
+    clearable
+    :placeholder="$t('app.relation_filter_value')"
+    @update:model-value="emitFilter"
+    @clear="clearValue"
+  />
+</template>
+
+<script>
+import { mapActions, mapState } from "pinia";
+import { useDataStore } from "@/stores/data";
+import { useAppStore } from "@/stores/app";
+import { fieldsSchema } from "@/assets/nativeFields";
+import { RELATION_FIELDS } from "@/services/relationResolver";
+
+export default {
+  name: "TheControlRelationFilter",
+  data() {
+    return {
+      relation: "",
+      property: "",
+      value: "",
+    };
+  },
+  computed: {
+    relationFields() {
+      return RELATION_FIELDS;
+    },
+    ...mapState(useAppStore, ["lang"]),
+    ...mapState(useDataStore, ["projectPreferencesFieldsWithTranslation"]),
+  },
+  methods: {
+    ...mapActions(useDataStore, ["setRelationFilter"]),
+    relationLabel(field) {
+      return fieldsSchema[field]?.labels?.[this.lang] ?? field;
+    },
+    emitFilter() {
+      if (this.relation && this.property && this.value?.trim()) {
+        this.setRelationFilter({
+          relation: this.relation,
+          property: this.property,
+          value: this.value,
+        });
+      } else {
+        this.setRelationFilter(null);
+      }
+    },
+    clearValue() {
+      this.value = "";
+      this.emitFilter();
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/src/components/TheMap.vue
+++ b/src/components/TheMap.vue
@@ -53,14 +53,14 @@ export default {
     ]),
     ...mapState(useDataStore, [
       "checkedTrenchesItemsPlans",
-      "checkedTrenchesItemsSelectedTypeAndSearched",
+      "checkedTrenchesItemsRelationFiltered",
       "projectPreferencesCRS",
       "tableFilteredCheckedTrenchesItems",
     ]),
     itemsForMap() {
       return (
         this.tableFilteredCheckedTrenchesItems ??
-        this.checkedTrenchesItemsSelectedTypeAndSearched
+        this.checkedTrenchesItemsRelationFiltered
       );
     },
   },

--- a/src/components/TheTable.vue
+++ b/src/components/TheTable.vue
@@ -102,7 +102,7 @@ export default {
       "projectTrenchesRights",
       "projectPreferencesTypesTranslationPlurals",
       "projectPreferencesTypesTranslation",
-      "checkedTrenchesItemsSelectedTypeAndSearched",
+      "checkedTrenchesItemsRelationFiltered",
       "tableFilteredCheckedTrenchesItems",
       "projectPreferencesBase64",
     ]),
@@ -110,7 +110,7 @@ export default {
     displayedItemsCount() {
       return this.tableFilteredCheckedTrenchesItems
         ? this.tableFilteredCheckedTrenchesItems.length
-        : this.checkedTrenchesItemsSelectedTypeAndSearched.length;
+        : this.checkedTrenchesItemsRelationFiltered.length;
     },
 
     columnsTabulator() {
@@ -201,7 +201,7 @@ export default {
       },
       // Treat field names as literal keys (do not parse dots as nested paths).
       nestedFieldSeparator: false,
-      data: this.checkedTrenchesItemsSelectedTypeAndSearched, //link data to table
+      data: this.checkedTrenchesItemsRelationFiltered, //link data to table
       // reactiveData: true, //turn on data reactivity
       layout: "fitColumns", //fit columns to width of table (optional)
       printAsHtml: true,
@@ -251,7 +251,7 @@ export default {
     });
 
     this.$watch(
-      () => this.checkedTrenchesItemsSelectedTypeAndSearched,
+      () => this.checkedTrenchesItemsRelationFiltered,
       (newRows) => {
         if (this.tabulator) {
           this.tabulator.replaceData(newRows);

--- a/src/components/__tests__/TheControlRelationFilter.spec.js
+++ b/src/components/__tests__/TheControlRelationFilter.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { useDataStore } from "@/stores/data";
+import TheControlRelationFilter from "@/components/TheControlRelationFilter.vue";
+
+function mountComponent() {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const wrapper = mount(TheControlRelationFilter, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: { "q-input": true, "q-tooltip": true },
+    },
+  });
+  return { wrapper, store: useDataStore() };
+}
+
+describe("TheControlRelationFilter", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("should dispatch a relation filter when all fields are set", () => {
+    const { wrapper, store } = mountComponent();
+    wrapper.vm.relation = "RelationBelongsToUUID";
+    wrapper.vm.property = "Phase";
+    wrapper.vm.value = "Use";
+    wrapper.vm.emitFilter();
+    expect(store.relationFilter).toEqual({
+      relation: "RelationBelongsToUUID",
+      property: "Phase",
+      value: "Use",
+    });
+  });
+
+  it("should dispatch null when the value is empty", () => {
+    const { wrapper, store } = mountComponent();
+    wrapper.vm.relation = "RelationBelongsToUUID";
+    wrapper.vm.property = "Phase";
+    wrapper.vm.value = "";
+    wrapper.vm.emitFilter();
+    expect(store.relationFilter).toBeNull();
+  });
+
+  it("should dispatch null when clearing the value", () => {
+    const { wrapper, store } = mountComponent();
+    wrapper.vm.relation = "RelationBelongsToUUID";
+    wrapper.vm.property = "Phase";
+    wrapper.vm.value = "Use";
+    wrapper.vm.emitFilter();
+    wrapper.vm.clearValue();
+    expect(wrapper.vm.value).toBe("");
+    expect(store.relationFilter).toBeNull();
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,6 +19,11 @@
     "lastLogin": "Last login",
     "createProfile": "Create a profile to connect to the server",
     "exportProfiles": "Export profiles",
-    "importProfiles": "Import profiles"
+    "importProfiles": "Import profiles",
+    "relation_filter_title": "Relational filter",
+    "relation_filter_tip": "Filter items by a property of their related items",
+    "relation_filter_relation": "Select a relation",
+    "relation_filter_property": "Select a field",
+    "relation_filter_value": "Value…"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -19,6 +19,11 @@
     "lastLogin": "Dernière connexion",
     "createProfile": "Créer un profil",
     "exportProfiles": "Exporter les profils",
-    "importProfiles": "Importer les profils"
+    "importProfiles": "Importer les profils",
+    "relation_filter_title": "Filtre relationnel",
+    "relation_filter_tip": "Filtrer les éléments selon une propriété de leurs éléments liés",
+    "relation_filter_relation": "Choisir une relation",
+    "relation_filter_property": "Choisir un champ",
+    "relation_filter_value": "Valeur…"
   }
 }

--- a/src/services/__tests__/relationResolver.spec.js
+++ b/src/services/__tests__/relationResolver.spec.js
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  RELATION_FIELDS,
+  parseUuidList,
+  buildUuidIndex,
+  resolveRelatedItems,
+} from "@/services/relationResolver";
+
+describe("relationResolver", () => {
+  describe("RELATION_FIELDS", () => {
+    it("should list the UUID relation fields", () => {
+      expect(RELATION_FIELDS).toContain("RelationBelongsToUUID");
+      expect(RELATION_FIELDS).toContain("RelationIncludesUUID");
+      expect(RELATION_FIELDS).toContain("RelationIsAboveUUID");
+    });
+
+    it("should exclude non-UUID link fields", () => {
+      expect(RELATION_FIELDS).not.toContain("RelationAttachments");
+      RELATION_FIELDS.forEach((field) => {
+        expect(field).toMatch(/^Relation.*UUID$/);
+      });
+    });
+  });
+
+  describe("parseUuidList", () => {
+    it("should return an empty array for null or undefined", () => {
+      expect(parseUuidList(null)).toEqual([]);
+      expect(parseUuidList(undefined)).toEqual([]);
+    });
+
+    it("should wrap a single value in an array", () => {
+      expect(parseUuidList("uuid-1")).toEqual(["uuid-1"]);
+    });
+
+    it("should split multiple values on newlines", () => {
+      expect(parseUuidList("uuid-1\nuuid-2")).toEqual(["uuid-1", "uuid-2"]);
+    });
+
+    it("should drop empty segments", () => {
+      expect(parseUuidList("uuid-1\n\nuuid-2\n")).toEqual(["uuid-1", "uuid-2"]);
+    });
+  });
+
+  describe("buildUuidIndex", () => {
+    it("should key items by their IdentifierUUID", () => {
+      const items = [
+        { IdentifierUUID: "u1", Title: "A" },
+        { IdentifierUUID: "u2", Title: "B" },
+      ];
+      const index = buildUuidIndex(items);
+      expect(index.get("u1").Title).toBe("A");
+      expect(index.get("u2").Title).toBe("B");
+    });
+
+    it("should skip items without an IdentifierUUID", () => {
+      const index = buildUuidIndex([{ Title: "no uuid" }]);
+      expect(index.size).toBe(0);
+    });
+
+    it("should return an empty Map for non-array input", () => {
+      expect(buildUuidIndex(null).size).toBe(0);
+    });
+  });
+
+  describe("resolveRelatedItems", () => {
+    const index = buildUuidIndex([
+      { IdentifierUUID: "u1", Title: "Parent" },
+      { IdentifierUUID: "u2", Title: "Sibling" },
+    ]);
+
+    it("should resolve every related UUID to its item", () => {
+      const item = { RelationBelongsToUUID: "u1\nu2" };
+      const related = resolveRelatedItems(item, "RelationBelongsToUUID", index);
+      expect(related.map((r) => r.Title)).toEqual(["Parent", "Sibling"]);
+    });
+
+    it("should ignore UUIDs missing from the index", () => {
+      const item = { RelationBelongsToUUID: "u1\nunknown" };
+      const related = resolveRelatedItems(item, "RelationBelongsToUUID", index);
+      expect(related.map((r) => r.Title)).toEqual(["Parent"]);
+    });
+
+    it("should return an empty array when the relation field is empty", () => {
+      expect(resolveRelatedItems({}, "RelationBelongsToUUID", index)).toEqual(
+        [],
+      );
+    });
+
+    it("should return an empty array without an item or index", () => {
+      expect(resolveRelatedItems(null, "RelationBelongsToUUID", index)).toEqual(
+        [],
+      );
+      expect(
+        resolveRelatedItems({ RelationBelongsToUUID: "u1" }, "x", null),
+      ).toEqual([]);
+    });
+  });
+});

--- a/src/services/indexedDbManager.js
+++ b/src/services/indexedDbManager.js
@@ -1,6 +1,6 @@
 export const openDB = () => {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open("iDigIndexedDB", 1);
+    const request = indexedDB.open("iDigIndexedDB");
 
     request.onupgradeneeded = (event) => {
       const db = event.target.result;

--- a/src/services/relationResolver.js
+++ b/src/services/relationResolver.js
@@ -1,0 +1,35 @@
+import { fieldsSchema } from "@/assets/nativeFields";
+
+export const RELATION_FIELDS = Object.keys(fieldsSchema).filter(
+  (field) =>
+    fieldsSchema[field]?.type === "link" && /^Relation.*UUID$/.test(field),
+);
+
+export function parseUuidList(value) {
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return String(value).split("\n").filter(Boolean);
+}
+
+export function buildUuidIndex(items) {
+  const index = new Map();
+  if (!Array.isArray(items)) {
+    return index;
+  }
+  for (const item of items) {
+    if (item?.IdentifierUUID) {
+      index.set(item.IdentifierUUID, item);
+    }
+  }
+  return index;
+}
+
+export function resolveRelatedItems(item, relationField, index) {
+  if (!item || !index) {
+    return [];
+  }
+  return parseUuidList(item[relationField])
+    .map((uuid) => index.get(uuid))
+    .filter(Boolean);
+}

--- a/src/stores/__tests__/data.spec.js
+++ b/src/stores/__tests__/data.spec.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useDataStore } from "@/stores/data";
+
+function makeStore() {
+  const store = useDataStore();
+  store.checkedTrenchesData = {
+    T1: [
+      { Type: "Context", IdentifierUUID: "c-use", Phase: "Use", Trench: "T1" },
+      {
+        Type: "Context",
+        IdentifierUUID: "c-fill",
+        Phase: "Fill",
+        Trench: "T1",
+      },
+      {
+        Type: "Context",
+        IdentifierUUID: "c-accent",
+        Phase: "Élevé",
+        Trench: "T1",
+      },
+      {
+        Type: "Artifact",
+        Identifier: "A1",
+        IdentifierUUID: "a1",
+        RelationBelongsToUUID: "c-use",
+        Trench: "T1",
+      },
+      {
+        Type: "Artifact",
+        Identifier: "A2",
+        IdentifierUUID: "a2",
+        RelationBelongsToUUID: "c-fill",
+        Trench: "T1",
+      },
+      {
+        Type: "Artifact",
+        Identifier: "A3",
+        IdentifierUUID: "a3",
+        RelationBelongsToUUID: "c-accent",
+        Trench: "T1",
+      },
+      {
+        Type: "Artifact",
+        Identifier: "A4",
+        IdentifierUUID: "a4",
+        RelationBelongsToUUID: "c-in-t2",
+        Trench: "T1",
+      },
+    ],
+    T2: [
+      {
+        Type: "Context",
+        IdentifierUUID: "c-in-t2",
+        Phase: "Use",
+        Trench: "T2",
+      },
+    ],
+  };
+  return store;
+}
+
+describe("data store — relational filter engine", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  describe("uuidIndexByTrench", () => {
+    it("should build one UUID index per trench", () => {
+      const store = makeStore();
+      expect(store.uuidIndexByTrench.T1.get("c-use").Phase).toBe("Use");
+      expect(store.uuidIndexByTrench.T2.get("c-in-t2").Phase).toBe("Use");
+      expect(store.uuidIndexByTrench.T1.has("c-in-t2")).toBe(false);
+    });
+  });
+
+  describe("checkedTrenchesItemsRelationFiltered", () => {
+    it("should return the searched list untouched when no filter is set", () => {
+      const store = makeStore();
+      expect(store.checkedTrenchesItemsRelationFiltered).toEqual(
+        store.checkedTrenchesItemsSelectedTypeAndSearched,
+      );
+    });
+
+    it("should keep only items whose related item matches the property", () => {
+      const store = makeStore();
+      store.setRelationFilter({
+        relation: "RelationBelongsToUUID",
+        property: "Phase",
+        value: "use",
+      });
+      const identifiers = store.checkedTrenchesItemsRelationFiltered.map(
+        (item) => item.Identifier,
+      );
+      expect(identifiers).toEqual(["A1"]);
+    });
+
+    it("should be accent-insensitive on the related property", () => {
+      const store = makeStore();
+      store.setRelationFilter({
+        relation: "RelationBelongsToUUID",
+        property: "Phase",
+        value: "eleve",
+      });
+      const identifiers = store.checkedTrenchesItemsRelationFiltered.map(
+        (item) => item.Identifier,
+      );
+      expect(identifiers).toEqual(["A3"]);
+    });
+
+    it("should not resolve relations across trenches", () => {
+      const store = makeStore();
+      store.setRelationFilter({
+        relation: "RelationBelongsToUUID",
+        property: "Phase",
+        value: "use",
+      });
+      const identifiers = store.checkedTrenchesItemsRelationFiltered.map(
+        (item) => item.Identifier,
+      );
+      expect(identifiers).not.toContain("A4");
+    });
+
+    it("should ignore a filter with an empty value", () => {
+      const store = makeStore();
+      store.setRelationFilter({
+        relation: "RelationBelongsToUUID",
+        property: "Phase",
+        value: "   ",
+      });
+      expect(store.checkedTrenchesItemsRelationFiltered).toEqual(
+        store.checkedTrenchesItemsSelectedTypeAndSearched,
+      );
+    });
+  });
+});

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -18,6 +18,14 @@ import {
 } from "@/services/indexedDbManager";
 import { fieldsSchema } from "@/assets/nativeFields";
 import { resolveProjectCrs } from "@/services/coordinateUtils";
+import {
+  buildUuidIndex,
+  resolveRelatedItems,
+} from "@/services/relationResolver";
+
+function normalizeText(value) {
+  return String(value).toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+}
 
 export const useDataStore = defineStore("data", {
   state: () => ({
@@ -40,6 +48,7 @@ export const useDataStore = defineStore("data", {
     // Holds the subset of items currently visible in the Tabulator table
     // (set by TheTable component when the user applies client-side filters)
     tableFilteredCheckedTrenchesItems: null,
+    relationFilter: null,
   }),
 
   getters: {
@@ -141,6 +150,14 @@ export const useDataStore = defineStore("data", {
 
     checkedTrenchesItems(state) {
       return [].concat(...Object.values(state.checkedTrenchesData));
+    },
+
+    uuidIndexByTrench(state) {
+      const index = {};
+      for (const [trench, items] of Object.entries(state.checkedTrenchesData)) {
+        index[trench] = buildUuidIndex(items);
+      }
+      return index;
     },
 
     checkedTrenchesItemsPlans(state) {
@@ -295,6 +312,34 @@ export const useDataStore = defineStore("data", {
         }
         return searchProperty;
       }
+    },
+
+    checkedTrenchesItemsRelationFiltered(state) {
+      const filter = state.relationFilter;
+      if (
+        !filter ||
+        !filter.relation ||
+        !filter.property ||
+        !filter.value?.trim()
+      ) {
+        return state.checkedTrenchesItemsSelectedTypeAndSearched;
+      }
+
+      const needle = normalizeText(filter.value.trim());
+      const indexByTrench = this.uuidIndexByTrench;
+      const items = state.checkedTrenchesItemsSelectedTypeAndSearched;
+
+      return items.filter((item) => {
+        const related = resolveRelatedItems(
+          item,
+          filter.relation,
+          indexByTrench[item.Trench],
+        );
+        return related.some((relatedItem) => {
+          const haystack = normalizeText(relatedItem?.[filter.property] ?? "");
+          return haystack.includes(needle);
+        });
+      });
     },
   },
 
@@ -499,6 +544,10 @@ export const useDataStore = defineStore("data", {
 
     setTableFilteredCheckedTrenchesItems(items) {
       this.tableFilteredCheckedTrenchesItems = items;
+    },
+
+    setRelationFilter(relationFilter) {
+      this.relationFilter = relationFilter;
     },
 
     setSyncPatches(syncPatches) {


### PR DESCRIPTION
# Issue

https://github.com/esag-swiss/iDig-Webapp/issues/224

# Description

## Contexte

[P1-02] Les items iDig sont reliés par des champs UUID (`RelationBelongsToUUID`,
`RelationIncludesUUID`, `RelationIsAboveUUID`, …), stockés en chaînes multi-valeurs
séparées par des `\n`. Jusqu'ici il n'existait **aucun index UUID**, **aucun
résolveur de relations partagé** (logique dupliquée dans 4 composants), et il était
**impossible de filtrer les items selon les propriétés de leurs items liés**.

Cette MR ajoute un **moteur de filtrage relationnel** complet (index + résolveur +
filtre Pinia) et le contrôle UI associé.

## Changements

**Moteur**
- `src/services/relationResolver.js` (nouveau) — service pur et testé :
  `RELATION_FIELDS`, `parseUuidList`, `buildUuidIndex`, `resolveRelatedItems`.
- `src/stores/data.js` :
  - getter `uuidIndexByTrench` — un index `Map<UUID, item>` **par trench** ;
  - état `relationFilter` + action `setRelationFilter` ;
  - getter terminal `checkedTrenchesItemsRelationFiltered` (accent-insensible,
    helper `normalizeText` factorisé), branché en fin de chaîne de filtrage.

**UI**
- `src/components/TheControlRelationFilter.vue` (nouveau) — relation + champ +
  valeur, monté dans `App.vue`.
- Clés i18n `snake_case` ajoutées dans `fr.json` / `en.json`.

**Consommateurs**
- `TheTable.vue` et `TheMap.vue` repointés vers le getter terminal → tableau,
  compteur et carte suivent le filtre.

## Tests

- 3 nouveaux fichiers de tests, **22 cas** (résolveur, getters du store, composant).
- Suite complète : **67/67 verts**. Fichiers ajoutés propres à ESLint et Prettier.

## Points d'attention

- **Résolution scoppée par trench** : une relation vers un UUID d'une autre trench
  n'est volontairement pas résolue (comportement historique conservé, test dédié).
- **Pas de migration des 4 composants existants** (`TheItem*`, `TheTable`,
  `TheItemLink`) vers le nouveau service — prévu dans un ticket dédié pour éviter
  les régressions.
- Les avertissements ESLint/Prettier résiduels sur `data.js` / `TheTable.vue` sont
  **pré-existants** ; cette MR n'en introduit aucun.