### PR TITLE
feat(search): add JMESPath expert search mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "idig",
       "version": "0.0.0",
       "dependencies": {
+        "@jmespath-community/jmespath": "^1.3.0",
         "@quasar/extras": "^1.18.0",
         "@sentry/vue": "^10.52.0",
         "axios": "^1.15.2",
@@ -1036,6 +1037,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@jmespath-community/jmespath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jmespath-community/jmespath/-/jmespath-1.3.0.tgz",
+      "integrity": "sha512-nzOrEdWKNpognj6CT+1Atr7gw0bqUC1KTBRyasBXS9NjFpz+og7LeFZrIQqV81GRcCzKa5H+DNipvv7NQK3GzA==",
+      "license": "MPL-2.0",
+      "bin": {
+        "jp": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@jmespath-community/jmespath": "^1.3.0",
     "@quasar/extras": "^1.18.0",
     "@sentry/vue": "^10.52.0",
     "axios": "^1.15.2",

--- a/src/components/TheControlSearch.vue
+++ b/src/components/TheControlSearch.vue
@@ -1,21 +1,49 @@
 <template>
   <div>
-    <q-tooltip class="bg-accent"
+    <q-btn-toggle
+      :model-value="searchMode"
+      spread
+      no-caps
+      dense
+      unelevated
+      toggle-color="primary"
+      color="white"
+      text-color="primary"
+      size="sm"
+      class="mb-1 border"
+      :options="[
+        { label: $t('app.search_mode_basic'), value: 'basic' },
+        { label: $t('app.search_mode_expert'), value: 'expert' },
+      ]"
+      @update:model-value="onModeChange"
+    />
+
+    <q-tooltip v-if="searchMode === 'basic'" class="bg-accent"
       >Search is case and diacritics sensitive only when search terms are
       enclosed within double quotation marks.<br />Operators AND and OR are
       accepted but can't be combined.<br />You can search within a specific
       field by mentioning the label in the current language before the colon.<br />
       <i>e.g.</i>: 'Titre:"Fusaï" OR spindle'.
     </q-tooltip>
+    <q-tooltip v-else class="bg-accent">
+      {{ $t("app.search_expert_help") }}
+    </q-tooltip>
+
     <q-input
       v-model="searchTextValue"
       square
       filled
       dense
       :clearable="searchText !== null"
-      placeholder="Search..."
-      @clear="setSearchText('')"
-      @update:model-value="setSearchText(searchTextValue)"
+      :placeholder="
+        searchMode === 'expert'
+          ? $t('app.search_expert_placeholder')
+          : $t('app.search_placeholder')
+      "
+      :error="expertError !== null"
+      :error-message="expertError"
+      @clear="onClear"
+      @update:model-value="onInput"
     />
   </div>
 </template>
@@ -23,19 +51,42 @@
 <script>
 import { mapActions, mapState } from "pinia";
 import { useDataStore } from "@/stores/data";
+import { validateExpression } from "@/services/expertSearch";
 
 export default {
   name: "TheControlSearch",
   data() {
     return {
       searchTextValue: "",
+      expertError: null,
     };
   },
   computed: {
-    ...mapState(useDataStore, ["searchText"]),
+    ...mapState(useDataStore, ["searchText", "searchMode"]),
   },
   methods: {
-    ...mapActions(useDataStore, ["setSearchText"]),
+    ...mapActions(useDataStore, ["setSearchText", "setSearchMode"]),
+    onInput(value) {
+      if (this.searchMode === "expert") {
+        const { valid, error } = validateExpression(value ?? "");
+        if (!valid) {
+          this.expertError = `${this.$t("app.search_expert_error")} ${error}`;
+          return;
+        }
+        this.expertError = null;
+      }
+      this.setSearchText(value ?? "");
+    },
+    onClear() {
+      this.expertError = null;
+      this.setSearchText("");
+    },
+    onModeChange(mode) {
+      this.setSearchMode(mode);
+      this.searchTextValue = "";
+      this.expertError = null;
+      this.setSearchText("");
+    },
   },
 };
 </script>

--- a/src/components/__tests__/TheControlSearch.spec.js
+++ b/src/components/__tests__/TheControlSearch.spec.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import TheControlSearch from "@/components/TheControlSearch.vue";
+import { useDataStore } from "@/stores/data";
+
+function mountComponent() {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const store = useDataStore(pinia);
+  const wrapper = mount(TheControlSearch, {
+    global: {
+      plugins: [pinia],
+      mocks: { $t: (key) => key },
+      stubs: {
+        "q-btn-toggle": true,
+        "q-input": true,
+        "q-tooltip": true,
+      },
+    },
+  });
+  return { wrapper, store };
+}
+
+describe("TheControlSearch", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("should default to basic mode", () => {
+    const { store } = mountComponent();
+    expect(store.searchMode).toBe("basic");
+  });
+
+  it("should switch to expert mode and reset the query on toggle", () => {
+    const { wrapper, store } = mountComponent();
+    const setSearchText = vi.spyOn(store, "setSearchText");
+    wrapper.vm.onModeChange("expert");
+    expect(store.searchMode).toBe("expert");
+    expect(setSearchText).toHaveBeenCalledWith("");
+  });
+
+  it("should show an inline error and not commit an invalid expert expression", () => {
+    const { wrapper, store } = mountComponent();
+    store.setSearchMode("expert");
+    const setSearchText = vi.spyOn(store, "setSearchText");
+    wrapper.vm.onInput("[?RightsStatus==]");
+    expect(wrapper.vm.expertError).toBeTruthy();
+    expect(setSearchText).not.toHaveBeenCalled();
+  });
+
+  it("should commit a valid expert expression and clear the error", () => {
+    const { wrapper, store } = mountComponent();
+    store.setSearchMode("expert");
+    const setSearchText = vi.spyOn(store, "setSearchText");
+    wrapper.vm.onInput("[?Type=='Context']");
+    expect(wrapper.vm.expertError).toBeNull();
+    expect(setSearchText).toHaveBeenCalledWith("[?Type=='Context']");
+  });
+
+  it("should commit the raw text in basic mode without validation", () => {
+    const { wrapper, store } = mountComponent();
+    const setSearchText = vi.spyOn(store, "setSearchText");
+    wrapper.vm.onInput("[?RightsStatus==]");
+    expect(wrapper.vm.expertError).toBeNull();
+    expect(setSearchText).toHaveBeenCalledWith("[?RightsStatus==]");
+  });
+});

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -14,6 +14,12 @@
     "typeTip": "Daten filtern und nur Felder anzeigen, die für den ausgewählten Typ oder Untertyp verfügbar sind",
     "fieldTip": "Verfügbare Felder für den ausgewählten Typ oder Untertyp",
     "upload local pref": "Lokale Einstellungen hochladen",
-    "upload pref from trench": " Einstellungen aus dem Sektor hochladen"
+    "upload pref from trench": " Einstellungen aus dem Sektor hochladen",
+    "search_mode_basic": "Einfach",
+    "search_mode_expert": "Experte",
+    "search_placeholder": "Suchen...",
+    "search_expert_placeholder": "JMESPath-Ausdruck, z. B. [?Type=='Context']",
+    "search_expert_help": "Expertenmodus: Filtern Sie Elemente mit einem JMESPath-Ausdruck, der auf den rohen Feldschlüsseln ausgewertet wird (Groß-/Kleinschreibung beachten). z. B. [?contains(Title, 'FK') && RightsStatus=='All Done']",
+    "search_expert_error": "Ungültiger Ausdruck:"
   }
 }

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -14,7 +14,13 @@
     "typeTip": " φιλτράρισμα δεδομένων και εμφάνιση μόνο των πεδίων που είναι διαθέσιμα για τον επιλεγμένο τύπο ή υποτύπο",
     "fieldTip": " διαθέσιμα πεδία για τον επιλεγμένο τύπο ή υποτύπο",
     "upload local pref": "Ανέβασμα τοπικού αρχείου προτιμήσεων",
-    "upload pref from trench": " Ανέβασμα προτιμήσεων από τον επιλεγμένο τομέα"
+    "upload pref from trench": " Ανέβασμα προτιμήσεων από τον επιλεγμένο τομέα",
+    "search_mode_basic": "Βασική",
+    "search_mode_expert": "Έμπειρη",
+    "search_placeholder": "Αναζήτηση...",
+    "search_expert_placeholder": "Έκφραση JMESPath, π.χ. [?Type=='Context']",
+    "search_expert_help": "Λειτουργία ειδικού: φιλτράρετε τα στοιχεία με μια έκφραση JMESPath που αξιολογείται στα ακατέργαστα κλειδιά πεδίων (με διάκριση πεζών-κεφαλαίων). π.χ. [?contains(Title, 'FK') && RightsStatus=='All Done']",
+    "search_expert_error": "Μη έγκυρη έκφραση:"
   },
   "buttons": {
     "save": "Αποθήκευση",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,6 +19,12 @@
     "lastLogin": "Last login",
     "createProfile": "Create a profile to connect to the server",
     "exportProfiles": "Export profiles",
-    "importProfiles": "Import profiles"
+    "importProfiles": "Import profiles",
+    "search_mode_basic": "Basic",
+    "search_mode_expert": "Expert",
+    "search_placeholder": "Search...",
+    "search_expert_placeholder": "JMESPath expression, e.g. [?Type=='Context']",
+    "search_expert_help": "Expert mode: filter items with a JMESPath expression evaluated on raw field keys (case sensitive). e.g. [?contains(Title, 'FK') && RightsStatus=='All Done']",
+    "search_expert_error": "Invalid expression:"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -19,6 +19,12 @@
     "lastLogin": "Dernière connexion",
     "createProfile": "Créer un profil",
     "exportProfiles": "Exporter les profils",
-    "importProfiles": "Importer les profils"
+    "importProfiles": "Importer les profils",
+    "search_mode_basic": "Basique",
+    "search_mode_expert": "Expert",
+    "search_placeholder": "Rechercher...",
+    "search_expert_placeholder": "Expression JMESPath, ex. [?Type=='Context']",
+    "search_expert_help": "Mode expert : filtrez les items avec une expression JMESPath évaluée sur les clés brutes (sensible à la casse). ex. [?contains(Title, 'FK') && RightsStatus=='All Done']",
+    "search_expert_error": "Expression invalide :"
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -14,6 +14,12 @@
     "typeTip": "filtrare i dati e mostrare solo i campi disponibili per il tipo o sottotipo selezionato",
     "fieldTip": "campi disponibili per il tipo o sottotipo selezionato",
     "upload local pref": "Carica file di preferenze locali",
-    "upload pref from trench": "Carica preferenze da un settore scelto"
+    "upload pref from trench": "Carica preferenze da un settore scelto",
+    "search_mode_basic": "Base",
+    "search_mode_expert": "Esperto",
+    "search_placeholder": "Cerca...",
+    "search_expert_placeholder": "Espressione JMESPath, es. [?Type=='Context']",
+    "search_expert_help": "Modalità esperto: filtra gli elementi con un'espressione JMESPath valutata sulle chiavi grezze (sensibile alle maiuscole). es. [?contains(Title, 'FK') && RightsStatus=='All Done']",
+    "search_expert_error": "Espressione non valida:"
   }
 }

--- a/src/services/__tests__/expertSearch.spec.js
+++ b/src/services/__tests__/expertSearch.spec.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { validateExpression, runExpression } from "@/services/expertSearch";
+
+const items = [
+  { Type: "Context", Title: "FK4178", RightsStatus: "All Done" },
+  { Type: "Context", Title: "FK4179", RightsStatus: "Draft" },
+  { Type: "Artifact", Title: "Spindle", RightsStatus: "All Done" },
+];
+
+describe("validateExpression", () => {
+  it("should return valid for a well-formed expression", () => {
+    expect(validateExpression("[?Type=='Context']")).toEqual({
+      valid: true,
+      error: null,
+    });
+  });
+
+  it("should return valid for an empty expression", () => {
+    expect(validateExpression("   ")).toEqual({ valid: true, error: null });
+  });
+
+  it("should return an error message for a malformed expression", () => {
+    const result = validateExpression("[?RightsStatus==]");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe("runExpression", () => {
+  it("should return all items for an empty expression", () => {
+    expect(runExpression(items, "")).toBe(items);
+  });
+
+  it("should filter items matching a JMESPath filter", () => {
+    const result = runExpression(items, "[?Type=='Context']");
+    expect(result).toHaveLength(2);
+    expect(result.map((item) => item.Title)).toEqual(["FK4178", "FK4179"]);
+  });
+
+  it("should support combined conditions", () => {
+    const result = runExpression(
+      items,
+      "[?RightsStatus=='All Done' && contains(Title, 'FK')]",
+    );
+    expect(result.map((item) => item.Title)).toEqual(["FK4178"]);
+  });
+
+  it("should return an empty array for an invalid expression", () => {
+    expect(runExpression(items, "[?RightsStatus==]")).toEqual([]);
+  });
+
+  it("should return an empty array when the result is not an array", () => {
+    expect(runExpression(items, "length(@)")).toEqual([]);
+  });
+});

--- a/src/services/expertSearch.js
+++ b/src/services/expertSearch.js
@@ -1,0 +1,27 @@
+import { compile, search } from "@jmespath-community/jmespath";
+
+export function validateExpression(expression) {
+  const trimmed = expression.trim();
+  if (trimmed === "") {
+    return { valid: true, error: null };
+  }
+  try {
+    compile(trimmed);
+    return { valid: true, error: null };
+  } catch (error) {
+    return { valid: false, error: error?.message ?? String(error) };
+  }
+}
+
+export function runExpression(items, expression) {
+  const trimmed = expression.trim();
+  if (trimmed === "") {
+    return items;
+  }
+  try {
+    const result = search(items, trimmed);
+    return Array.isArray(result) ? result : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/stores/data.js
+++ b/src/stores/data.js
@@ -18,6 +18,7 @@ import {
 } from "@/services/indexedDbManager";
 import { fieldsSchema } from "@/assets/nativeFields";
 import { resolveProjectCrs } from "@/services/coordinateUtils";
+import { runExpression } from "@/services/expertSearch";
 
 export const useDataStore = defineStore("data", {
   state: () => ({
@@ -31,6 +32,7 @@ export const useDataStore = defineStore("data", {
     checkedTrenchesData: {},
     checkedTrenchesVersion: lsLoadCheckedTrenchesVersion(),
     searchText: "",
+    searchMode: "basic",
     syncPatches: "",
     syncTrench: "",
     syncNewVersion: "",
@@ -181,6 +183,14 @@ export const useDataStore = defineStore("data", {
       // Early exit if no search text provided
       if (state.searchText.trim() === "") {
         return state.checkedTrenchesItemsSelectedTypeFiltered;
+      }
+
+      // Mode expert : évaluation d'une expression JMESPath
+      if (state.searchMode === "expert") {
+        return runExpression(
+          state.checkedTrenchesItemsSelectedTypeFiltered,
+          state.searchText,
+        );
       }
 
       const searchText = state.searchText.trim();
@@ -495,6 +505,10 @@ export const useDataStore = defineStore("data", {
 
     setSearchText(searchText) {
       this.searchText = searchText;
+    },
+
+    setSearchMode(searchMode) {
+      this.searchMode = searchMode;
     },
 
     setTableFilteredCheckedTrenchesItems(items) {


### PR DESCRIPTION
**Issue** : 

https://github.com/esag-swiss/iDig-Webapp/issues/225

**Description** :    

**Pourquoi**
La recherche basique (texte libre, `AND`/`OR`, `Label:"valeur"`) ne permet pas d'exprimer
des filtres complexes (conditions imbriquées, comparaisons, fonctions). Le mode expert offre
un champ d'expression JMESPath pour les utilisateurs avancés.

**Comment**
- Toggle `q-btn-toggle` Basic/Expert dans la barre de recherche (`TheControlSearch.vue`).
- Nouveau service `src/services/expertSearch.js` (`validateExpression`, `runExpression`)
  isolant la logique JMESPath — le getter du store reste pur.
- Le getter `checkedTrenchesItemsSelectedTypeAndSearched` branche sur `searchMode` :
  en mode expert, l'expression s'évalue sur les items du **Type courant** (cohérence
  tableau/carte), sur `checkedTrenchesItemsSelectedTypeFiltered`.
- Feedback d'erreur inline via `:error`/`:error-message` du `q-input` ; une expression
  invalide n'est pas propagée au store (résultats stables, pas de spam de notifications).
- i18n : 6 nouvelles clés `snake_case` dans les 5 locales (fr, en, de, it, el).

**À noter / compromis**
- JMESPath opère sur les **clés brutes** des items (`Title`, `RightsStatus`, `Type`…),
  pas sur les labels traduits (contrairement au mode basique) — documenté dans le tooltip
  d'aide du mode expert.
- Package ajouté : `@jmespath-community/jmespath` (fork ESM maintenu).
- Changement de mode : le champ est réinitialisé pour éviter d'interpréter une requête
  d'un mode dans l'autre.

**Scénarios**
- *Happy path* : `[?RightsStatus=='All Done' && contains(Title, 'FK')]` → filtre le tableau/carte.
- *Unhappy path* : `[?RightsStatus==]` → message d'erreur inline, résultats inchangés, pas d'exception.

**Tests**
- `expertSearch.spec.js` (service) + `TheControlSearch.spec.js` (composant) — 13 tests.
- Suite complète verte (58 tests), lint OK sur les fichiers ajoutés/modifiés.