### PR TITLE
239 impression de la fiche

### DIFF
--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -285,7 +285,10 @@
         >
           Extra fields
           <q-tooltip class="bg-accent"
-            >Fields not included in groups section, these fields are not included in any group in the project preferences, but they are present in the current item. They are displayed here for information purposes only.
+            >Fields not included in groups section, these fields are not
+            included in any group in the project preferences, but they are
+            present in the current item. They are displayed here for information
+            purposes only.
           </q-tooltip>
         </li>
         <!-- ROWS -->
@@ -335,7 +338,8 @@
 </template>
 
 <script>
-import dayjs from "dayjs";  
+import dayjs from "dayjs";
+import { apiFetchImageSRC } from "@/services/ApiClient";
 import { mapActions, mapState } from "pinia";
 import { useDataStore } from "@/stores/data";
 import { useAppStore } from "@/stores/app";
@@ -357,7 +361,6 @@ import TheItemValuelist from "@/components/TheItemValuelist.vue";
 import TheItemInput from "@/components/TheItemInput.vue";
 import { pushSurvey } from "@/services/pushSurveyService";
 import { resolveFieldDefinition } from "@/services/fieldDefinition";
-
 
 export default {
   name: "TheItem",
@@ -547,38 +550,29 @@ export default {
 
     async fetchImages() {
       let relatedItems = [];
-      if (this.selectedItem?.RelationAttachments) {
-        relatedItems = [this.selectedItem.IdentifierUUID];
-        // Récupérer les URL d'images pour chaque UUID trouvé
-        const imagePromises = relatedItems.map((uuid) =>
-          this.findObjectByUuid(uuid),
-        );
-        // Attendre la résolution de toutes les promesses d'URL d'images
-        const resolvedImages = await Promise.all(imagePromises);
-
-        // Filtrer les résultats pour ne garder que les valeurs non nulles
-        this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
-      }
       if (this.selectedItem?.RelationIncludesUUID && this.selectedItem.Trench) {
         if (this.selectedItem.RelationIncludesUUID.includes("\n")) {
           relatedItems = this.selectedItem.RelationIncludesUUID.split("\n");
         } else {
           relatedItems = [this.selectedItem.RelationIncludesUUID];
         }
-
-        // Récupérer les URL d'images pour chaque UUID trouvé
-        const imagePromises = relatedItems.map((uuid) =>
-          this.findObjectByUuid(uuid),
-        );
-        // Attendre la résolution de toutes les promesses d'URL d'images
-        const resolvedImages = await Promise.all(imagePromises);
-
-        // Filtrer les résultats pour ne garder que les valeurs non nulles
-        this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
       }
+      if (this.selectedItem?.RelationAttachments) {
+        relatedItems.push(this.selectedItem.IdentifierUUID);
+      }
+
+      // Récupérer les URL d'images pour chaque UUID trouvé
+      const imagePromises = relatedItems.map((uuid) =>
+        this.findRelationAttachmentsByUuid(uuid),
+      );
+      // Attendre la résolution de toutes les promesses d'URL d'images
+      const resolvedImages = await Promise.all(imagePromises);
+
+      // Filtrer les résultats pour ne garder que les valeurs non nulles
+      this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
     },
 
-    findObjectByUuid(IdentifierUUID) {
+    findRelationAttachmentsByUuid(IdentifierUUID) {
       // Vérifie si les données existent pour la tranchée actuelle
       const trenchData = this.checkedTrenchesData[this.selectedItem.Trench];
 
@@ -697,13 +691,23 @@ export default {
         .map((x) => x.trim())
         .filter(Boolean);
 
-      const trenchItems = this.checkedTrenchesData?.[this.selectedItem.Trench] || [];
+      const trenchItems =
+        this.checkedTrenchesData?.[this.selectedItem.Trench] || [];
 
       return uuids.map((uuid) => {
-        const fullItem = trenchItems.find((x) => x.IdentifierUUID.includes(uuid));
+        const fullItem = trenchItems.find((x) =>
+          x.IdentifierUUID.includes(uuid),
+        );
         return {
           relationField: fieldName,
-          type: fullItem ? this.itemLabelForPrint({ Type: fullItem.Type, Subtype: fullItem.Subtype, Identifier: "", Title: "" }).trim() : "Unknown",
+          type: fullItem
+            ? this.itemLabelForPrint({
+                Type: fullItem.Type,
+                Subtype: fullItem.Subtype,
+                Identifier: "",
+                Title: "",
+              }).trim()
+            : "Unknown",
           identifier: fullItem?.Identifier || "",
           title: fullItem?.Title || "",
           uuid,
@@ -720,7 +724,9 @@ export default {
       if (fieldName === "Type") {
         return (
           this.projectPreferencesTypesTranslation[this.selectedItem.Subtype] ||
-          this.projectPreferencesTypesTranslation[this.selectedItem[fieldName]] ||
+          this.projectPreferencesTypesTranslation[
+            this.selectedItem[fieldName]
+          ] ||
           this.selectedItem[fieldName]
         );
       }
@@ -742,7 +748,9 @@ export default {
         this.fieldDefinition(fieldName, group)?.hasOwnProperty("link")
       ) {
         return this.relationRowsForField(fieldName)
-          .map((row) => [row.type, row.identifier, row.title].filter(Boolean).join(" | "))
+          .map((row) =>
+            [row.type, row.identifier, row.title].filter(Boolean).join(" | "),
+          )
           .join("\n");
       }
 
@@ -761,14 +769,17 @@ export default {
       groups.forEach((group) => {
         const fields = group.fields.filter(
           (item) =>
-            this.fieldsOfCurrentItem.includes(item.field) && item.field !== "Subtype",
+            this.fieldsOfCurrentItem.includes(item.field) &&
+            item.field !== "Subtype",
         );
 
         let rowsHtml = "";
         fields.forEach((field) => {
           const fieldName = field.field;
           const label = this.escapeHtml(this.getFieldLabel(field, group));
-          const value = this.escapeHtml(this.scalarValueForPrint(fieldName, group));
+          const value = this.escapeHtml(
+            this.scalarValueForPrint(fieldName, group),
+          );
 
           // if (this.fieldsSchema[fieldName]?.type === "link") {
           //   allRelationRows.push(...this.relationRowsForField(fieldName));
@@ -778,7 +789,9 @@ export default {
         });
 
         if (rowsHtml) {
-          const groupLabel = this.escapeHtml(group.labels ? group.labels[this.lang] : group.group);
+          const groupLabel = this.escapeHtml(
+            group.labels ? group.labels[this.lang] : group.group,
+          );
           contentHtml += `
             <section>
               <h2>${groupLabel}</h2>
@@ -790,15 +803,16 @@ export default {
         }
       });
 
-
       const headerType =
-      this.project + " " +
+        this.project +
+        " " +
         (this.projectPreferencesTypesTranslation[this.selectedItem.Subtype] ||
-        this.projectPreferencesTypesTranslation[this.selectedItem.Type] ||
-        this.selectedItem.Type ||
-        "");
+          this.projectPreferencesTypesTranslation[this.selectedItem.Type] ||
+          this.selectedItem.Type ||
+          "");
 
-      const title = `${headerType} ${this.selectedItem.Identifier || ""}`.trim();
+      const title =
+        `${headerType} ${this.selectedItem.Identifier || ""}`.trim();
 
       const html = `
         <!doctype html>

--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -570,7 +570,7 @@ export default {
       this.relatedImageUrls = resolvedImages.filter((url) => url !== "null");
     },
 
-    findRelationAttachmentsByUuid(IdentifierUUID) {
+    findObjectByUuid(IdentifierUUID) {
       // Vérifie si les données existent pour la tranchée actuelle
       const trenchData = this.checkedTrenchesData[this.selectedItem.Trench];
 

--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -14,6 +14,17 @@
 
       <div class="mx-1">
         <q-btn
+          round
+          color="secondary"
+          icon="print"
+          :size="'sm'"
+          class="print-action"
+          @click="printItemSheet"
+        />
+        <q-tooltip class="bg-accent">print item as sheet</q-tooltip>
+      </div>
+      <div class="mx-1 no-print">
+        <q-btn
           v-if="editMode"
           round
           color="secondary"
@@ -25,7 +36,7 @@
           >upload curent trench modification to iDig server</q-tooltip
         >
       </div>
-      <div class="mx-1">
+      <div class="mx-1 no-print">
         <q-toggle
           v-model="editMode"
           :disable="
@@ -324,8 +335,7 @@
 </template>
 
 <script>
-import { Notify } from "quasar";
-import { apiPushTrench, apiFetchImageSRC } from "@/services/ApiClient";
+import dayjs from "dayjs";  
 import { mapActions, mapState } from "pinia";
 import { useDataStore } from "@/stores/data";
 import { useAppStore } from "@/stores/app";
@@ -347,6 +357,7 @@ import TheItemValuelist from "@/components/TheItemValuelist.vue";
 import TheItemInput from "@/components/TheItemInput.vue";
 import { pushSurvey } from "@/services/pushSurveyService";
 import { resolveFieldDefinition } from "@/services/fieldDefinition";
+
 
 export default {
   name: "TheItem",
@@ -386,7 +397,7 @@ export default {
       "checkedTrenchesItemsSelectedType",
       "selectedItem",
     ]),
-    ...mapState(useAppStore, ["username", "lang"]),
+    ...mapState(useAppStore, ["username", "lang", "project"]),
 
     //  array of fields presents in current item
     fieldsOfCurrentItem() {
@@ -640,6 +651,243 @@ export default {
     closeImage() {
       this.selectedImageUrl = null; // Réinitialiser l'URL pour masquer l'image
     },
+
+    escapeHtml(value) {
+      return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    },
+
+    getFieldLabel(field, group) {
+      return (
+        field.labels?.[this.lang] ||
+        this.projectPreferencesFieldsWithTranslation?.[field.field] ||
+        this.fieldsSchema?.[field.field]?.labels?.[this.lang] ||
+        field.field
+      );
+    },
+
+    itemLabelForPrint(item) {
+      if (!item) {
+        return "Unknown";
+      }
+
+      const typeLabel =
+        this.projectPreferencesTypesTranslation[item.Subtype] ||
+        this.projectPreferencesTypesTranslation[item.Type] ||
+        item.Type ||
+        "";
+
+      return [typeLabel, item.Identifier, item.Title]
+        .filter((part) => part && String(part).trim() !== "")
+        .join(" ");
+    },
+
+    relationRowsForField(fieldName) {
+      const raw = this.selectedItem?.[fieldName];
+      if (!raw) {
+        return [];
+      }
+
+      const uuids = String(raw)
+        .split("\n")
+        .map((x) => x.trim())
+        .filter(Boolean);
+
+      const trenchItems = this.checkedTrenchesData?.[this.selectedItem.Trench] || [];
+
+      return uuids.map((uuid) => {
+        const fullItem = trenchItems.find((x) => x.IdentifierUUID.includes(uuid));
+        return {
+          relationField: fieldName,
+          type: fullItem ? this.itemLabelForPrint({ Type: fullItem.Type, Subtype: fullItem.Subtype, Identifier: "", Title: "" }).trim() : "Unknown",
+          identifier: fullItem?.Identifier || "",
+          title: fullItem?.Title || "",
+          uuid,
+        };
+      });
+    },
+
+    scalarValueForPrint(fieldName, group) {
+      const value = this.selectedItem?.[fieldName];
+      if (value === undefined || value === null || value === "") {
+        return "";
+      }
+
+      if (fieldName === "Type") {
+        return (
+          this.projectPreferencesTypesTranslation[this.selectedItem.Subtype] ||
+          this.projectPreferencesTypesTranslation[this.selectedItem[fieldName]] ||
+          this.selectedItem[fieldName]
+        );
+      }
+
+      if (fieldName === "CoverageSerialized") {
+        return "geodata";
+      }
+
+      if (this.fieldsSchema[fieldName]?.type === "boolean") {
+        return String(value) === "1" ? "Yes" : "No";
+      }
+
+      if (this.fieldsSchema[fieldName]?.type === "DateUTC") {
+        return dayjs(value).format("DD/MM/YYYY");
+      }
+
+      if (
+        this.fieldsSchema[fieldName]?.type === "link" ||
+        this.fieldDefinition(fieldName, group)?.hasOwnProperty("link")
+      ) {
+        return this.relationRowsForField(fieldName)
+          .map((row) => [row.type, row.identifier, row.title].filter(Boolean).join(" | "))
+          .join("\n");
+      }
+
+      return String(value);
+    },
+
+    printItemSheet() {
+      if (!this.selectedItem) {
+        return;
+      }
+
+      const groups = this.groupsOfFieldsAccordingToItem;
+      let contentHtml = "";
+      const allRelationRows = [];
+
+      groups.forEach((group) => {
+        const fields = group.fields.filter(
+          (item) =>
+            this.fieldsOfCurrentItem.includes(item.field) && item.field !== "Subtype",
+        );
+
+        let rowsHtml = "";
+        fields.forEach((field) => {
+          const fieldName = field.field;
+          const label = this.escapeHtml(this.getFieldLabel(field, group));
+          const value = this.escapeHtml(this.scalarValueForPrint(fieldName, group));
+
+          // if (this.fieldsSchema[fieldName]?.type === "link") {
+          //   allRelationRows.push(...this.relationRowsForField(fieldName));
+          // }
+
+          rowsHtml += `<tr><th style="width: 15%;">${label}</th><td>${value.replace(/\n/g, "<br>")}</td></tr>`;
+        });
+
+        if (rowsHtml) {
+          const groupLabel = this.escapeHtml(group.labels ? group.labels[this.lang] : group.group);
+          contentHtml += `
+            <section>
+              <h2>${groupLabel}</h2>
+              <table>
+                <tbody>${rowsHtml}</tbody>
+              </table>
+            </section>
+          `;
+        }
+      });
+
+
+      const headerType =
+      this.project + " " +
+        (this.projectPreferencesTypesTranslation[this.selectedItem.Subtype] ||
+        this.projectPreferencesTypesTranslation[this.selectedItem.Type] ||
+        this.selectedItem.Type ||
+        "");
+
+      const title = `${headerType} ${this.selectedItem.Identifier || ""}`.trim();
+
+      const html = `
+        <!doctype html>
+        <html>
+          <head>
+            <meta charset="utf-8" />
+            <title>${this.escapeHtml(title)}</title>
+            <style>
+              body {
+                font-family: Arial, sans-serif;
+                color: #000;
+                background: #fff;
+                margin: 40px;
+                font-size: 12px;
+                line-height: 1.4;
+              }
+              h1 {
+                font-size: 22 px;
+                margin: 0 0 12px 0;
+              }
+              h2 {
+                font-size: 14px;
+                margin: 18px 0 8px 0;
+              }
+              table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-bottom: 10px;
+              }
+              th,
+              td {
+                border: 1px solid #333;
+                padding: 6px;
+                text-align: left;
+                vertical-align: top;
+              }
+              th {
+                width: 30%;
+                background: #f2f2f2;
+              }
+              @media print {
+                body {
+                  margin: 40px;
+                }
+              }
+            </style>
+          </head>
+          <body>
+            <h1>${this.escapeHtml(title)}</h1>
+            ${contentHtml}
+          </body>
+        </html>
+      `;
+
+      const iframe = document.createElement("iframe");
+      iframe.style.position = "fixed";
+      iframe.style.right = "0";
+      iframe.style.bottom = "0";
+      iframe.style.width = "0";
+      iframe.style.height = "0";
+      iframe.style.border = "0";
+      document.body.appendChild(iframe);
+
+      const frameDoc = iframe.contentWindow?.document;
+      if (!frameDoc || !iframe.contentWindow) {
+        document.body.removeChild(iframe);
+        return;
+      }
+
+      frameDoc.open();
+      frameDoc.write(html);
+      frameDoc.close();
+
+      const runPrint = () => {
+        iframe.contentWindow.focus();
+        iframe.contentWindow.print();
+        setTimeout(() => {
+          if (document.body.contains(iframe)) {
+            document.body.removeChild(iframe);
+          }
+        }, 300);
+      };
+
+      if (frameDoc.readyState === "complete") {
+        runPrint();
+      } else {
+        iframe.onload = runPrint;
+      }
+    },
   },
 };
 </script>
@@ -712,6 +960,58 @@ export default {
   max-height: 90%; /* Hauteur maximale de 90% de l'écran */
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5); /* Optionnel, ajoute une ombre */
   cursor: pointer;
+}
+
+@media print {
+  .TheItemwrapper {
+    position: static;
+    width: 100%;
+    height: auto;
+    overflow: visible;
+    border-radius: 0;
+    background: #fff;
+    padding: 0;
+  }
+
+  .sticky-top {
+    position: static;
+  }
+
+  .no-print,
+  .print-action,
+  .image-overlay,
+  .thumbnails-container,
+  .img-thumbnail {
+    display: none !important;
+  }
+
+  .TheItem {
+    margin-top: 0;
+    width: 100%;
+  }
+
+  .TheItemwrapper,
+  .TheItemwrapper * {
+    color: #000 !important;
+    -webkit-text-fill-color: #000 !important;
+  }
+
+  .TheItemwrapper,
+  .TheItem,
+  .list-group,
+  .list-group-item,
+  .accordion {
+    background: #fff !important;
+  }
+
+  .q-field,
+  .q-field__control,
+  .q-field__native,
+  .q-field__input,
+  .q-field__label {
+    color: #000 !important;
+    background: #fff !important;
+  }
 }
 </style>
 <style>


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/239`

**Description** :    
This pull request introduces a "print item as sheet" feature to the `TheItem.vue` component, allowing users to print a formatted sheet of the current item. 

**Print feature implementation and UI changes:**

* Added a print button (`q-btn` with print icon) to the item actions, which triggers the new `printItemSheet` method to generate and print a formatted HTML sheet of the current item. [[1]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bR16-R26) [[2]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bR648-R904)
* Introduced print-specific CSS to hide UI elements not relevant for printing (e.g., image thumbnails, action buttons) and ensure the printed sheet is clean and readable.


**Other improvements:**

* Added `project` to the mapped state properties for use in the print sheet header and elsewhere.
* Minor tooltip and code formatting adjustments for clarity and maintainability. [[1]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL277-R291) [[2]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL327-R342) [[3]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL28-R39)