### PR TITLE
254 refactor print feature in thitem

### DIFF
--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -169,7 +169,6 @@
               anchor="bottom left"
               self="top left"
               class="bg-accent"
-              style="white-space: pre-line"
               >({{ field.field }})<br />
               {{ fieldDefinition(field.field, group).tips[lang] }}</q-tooltip
             >
@@ -338,7 +337,6 @@
 </template>
 
 <script>
-import dayjs from "dayjs";
 import { apiFetchImageSRC } from "@/services/ApiClient";
 import { mapActions, mapState } from "pinia";
 import { useDataStore } from "@/stores/data";
@@ -361,6 +359,7 @@ import TheItemValuelist from "@/components/TheItemValuelist.vue";
 import TheItemInput from "@/components/TheItemInput.vue";
 import { pushSurvey } from "@/services/pushSurveyService";
 import { resolveFieldDefinition } from "@/services/fieldDefinition";
+import { printItemSheet as printItemSheetDocument } from "@/services/itemPrint";
 
 export default {
   name: "TheItem",
@@ -644,264 +643,26 @@ export default {
       this.selectedImageUrl = null; // Réinitialiser l'URL pour masquer l'image
     },
 
-    escapeHtml(value) {
-      return String(value ?? "")
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/\"/g, "&quot;")
-        .replace(/'/g, "&#39;");
-    },
-
-    getFieldLabel(field, group) {
-      return (
-        field.labels?.[this.lang] ||
-        this.projectPreferencesFieldsWithTranslation?.[field.field] ||
-        this.fieldsSchema?.[field.field]?.labels?.[this.lang] ||
-        field.field
-      );
-    },
-
-    itemLabelForPrint(item) {
-      if (!item) {
-        return "Unknown";
-      }
-
-      const typeLabel =
-        this.projectPreferencesTypesTranslation[item.Subtype] ||
-        this.projectPreferencesTypesTranslation[item.Type] ||
-        item.Type ||
-        "";
-
-      return [typeLabel, item.Identifier, item.Title]
-        .filter((part) => part && String(part).trim() !== "")
-        .join(" ");
-    },
-
-    relationRowsForField(fieldName) {
-      const raw = this.selectedItem?.[fieldName];
-      if (!raw) {
-        return [];
-      }
-
-      const uuids = String(raw)
-        .split("\n")
-        .map((x) => x.trim())
-        .filter(Boolean);
-
-      const trenchItems =
-        this.checkedTrenchesData?.[this.selectedItem.Trench] || [];
-
-      return uuids.map((uuid) => {
-        const fullItem = trenchItems.find((x) =>
-          x.IdentifierUUID.includes(uuid),
-        );
-        return {
-          relationField: fieldName,
-          type: fullItem
-            ? this.itemLabelForPrint({
-                Type: fullItem.Type,
-                Subtype: fullItem.Subtype,
-                Identifier: "",
-                Title: "",
-              }).trim()
-            : "Unknown",
-          identifier: fullItem?.Identifier || "",
-          title: fullItem?.Title || "",
-          uuid,
-        };
-      });
-    },
-
-    scalarValueForPrint(fieldName, group) {
-      const value = this.selectedItem?.[fieldName];
-      if (value === undefined || value === null || value === "") {
-        return "";
-      }
-
-      if (fieldName === "Type") {
-        return (
-          this.projectPreferencesTypesTranslation[this.selectedItem.Subtype] ||
-          this.projectPreferencesTypesTranslation[
-            this.selectedItem[fieldName]
-          ] ||
-          this.selectedItem[fieldName]
-        );
-      }
-
-      if (fieldName === "CoverageSerialized") {
-        return "geodata";
-      }
-
-      if (this.fieldsSchema[fieldName]?.type === "boolean") {
-        return String(value) === "1" ? "Yes" : "No";
-      }
-
-      if (this.fieldsSchema[fieldName]?.type === "DateUTC") {
-        return dayjs(value).format("DD/MM/YYYY");
-      }
-
-      if (
-        this.fieldsSchema[fieldName]?.type === "link" ||
-        this.fieldDefinition(fieldName, group)?.hasOwnProperty("link")
-      ) {
-        return this.relationRowsForField(fieldName)
-          .slice()
-          .sort((a, b) =>
-            String(a.identifier ?? "").localeCompare(
-              String(b.identifier ?? ""),
-              undefined,
-              { numeric: true, sensitivity: "base" },
-            ),
-          )
-          .map((row) =>
-            [row.type, row.identifier, row.title].filter(Boolean).join(" | "),
-          )
-          .join("\n");
-      }
-
-      return String(value);
-    },
-
     printItemSheet() {
       if (!this.selectedItem) {
         return;
       }
 
-      const groups = this.groupsOfFieldsAccordingToItem;
-      let contentHtml = "";
-
-      groups.forEach((group) => {
-        const fields = group.fields.filter(
-          (item) =>
-            this.fieldsOfCurrentItem.includes(item.field) &&
-            item.field !== "Subtype",
-        );
-
-        let rowsHtml = "";
-        fields.forEach((field) => {
-          const fieldName = field.field;
-          const label = this.escapeHtml(this.getFieldLabel(field, group));
-          const value = this.escapeHtml(
-            this.scalarValueForPrint(fieldName, group),
-          );
-
-          rowsHtml += `<tr><th style="width: 15%;">${label}</th><td>${value.replace(/\n/g, "<br>")}</td></tr>`;
-        });
-
-        if (rowsHtml) {
-          const groupLabel = this.escapeHtml(
-            group.labels ? group.labels[this.lang] : group.group,
-          );
-          contentHtml += `
-            <section>
-              <h2>${groupLabel}</h2>
-              <table>
-                <tbody>${rowsHtml}</tbody>
-              </table>
-            </section>
-          `;
-        }
+      printItemSheetDocument({
+        selectedItem: this.selectedItem,
+        groups: this.groupsOfFieldsAccordingToItem,
+        fieldsOfCurrentItem: this.fieldsOfCurrentItem,
+        lang: this.lang,
+        project: this.project,
+        projectPreferencesTypes: this.projectPreferencesTypes,
+        projectPreferencesTypesTranslation:
+          this.projectPreferencesTypesTranslation,
+        projectPreferencesFields: this.projectPreferencesFields,
+        projectPreferencesFieldsWithTranslation:
+          this.projectPreferencesFieldsWithTranslation,
+        fieldsSchema: this.fieldsSchema,
+        checkedTrenchesData: this.checkedTrenchesData,
       });
-
-      const headerType =
-        this.project +
-        " " +
-        (this.projectPreferencesTypesTranslation[this.selectedItem.Subtype] ||
-          this.projectPreferencesTypesTranslation[this.selectedItem.Type] ||
-          this.selectedItem.Type ||
-          "");
-
-      const title =
-        `${headerType} ${this.selectedItem.Identifier || ""}`.trim();
-
-      const html = `
-        <!doctype html>
-        <html>
-          <head>
-            <meta charset="utf-8" />
-            <title>${this.escapeHtml(title)}</title>
-            <style>
-              body {
-                font-family: Arial, sans-serif;
-                color: #000;
-                background: #fff;
-                margin: 40px;
-                font-size: 12px;
-                line-height: 1.4;
-              }
-              h1 {
-                font-size: 22 px;
-                margin: 0 0 12px 0;
-              }
-              h2 {
-                font-size: 14px;
-                margin: 18px 0 8px 0;
-              }
-              table {
-                width: 100%;
-                border-collapse: collapse;
-                margin-bottom: 10px;
-              }
-              th,
-              td {
-                border: 1px solid #333;
-                padding: 6px;
-                text-align: left;
-                vertical-align: top;
-              }
-              th {
-                width: 30%;
-                background: #f2f2f2;
-              }
-              @media print {
-                body {
-                  margin: 40px;
-                }
-              }
-            </style>
-          </head>
-          <body>
-            <h1>${this.escapeHtml(title)}</h1>
-            ${contentHtml}
-          </body>
-        </html>
-      `;
-
-      const iframe = document.createElement("iframe");
-      iframe.style.position = "fixed";
-      iframe.style.right = "0";
-      iframe.style.bottom = "0";
-      iframe.style.width = "0";
-      iframe.style.height = "0";
-      iframe.style.border = "0";
-      document.body.appendChild(iframe);
-
-      const frameDoc = iframe.contentWindow?.document;
-      if (!frameDoc || !iframe.contentWindow) {
-        document.body.removeChild(iframe);
-        return;
-      }
-
-      frameDoc.open();
-      frameDoc.write(html);
-      frameDoc.close();
-
-      const runPrint = () => {
-        iframe.contentWindow.focus();
-        iframe.contentWindow.print();
-        setTimeout(() => {
-          if (document.body.contains(iframe)) {
-            document.body.removeChild(iframe);
-          }
-        }, 300);
-      };
-
-      if (frameDoc.readyState === "complete") {
-        runPrint();
-      } else {
-        iframe.onload = runPrint;
-      }
     },
   },
 };

--- a/src/components/TheItem.vue
+++ b/src/components/TheItem.vue
@@ -746,6 +746,14 @@ export default {
         this.fieldDefinition(fieldName, group)?.hasOwnProperty("link")
       ) {
         return this.relationRowsForField(fieldName)
+          .slice()
+          .sort((a, b) =>
+            String(a.identifier ?? "").localeCompare(
+              String(b.identifier ?? ""),
+              undefined,
+              { numeric: true, sensitivity: "base" },
+            ),
+          )
           .map((row) =>
             [row.type, row.identifier, row.title].filter(Boolean).join(" | "),
           )
@@ -762,7 +770,6 @@ export default {
 
       const groups = this.groupsOfFieldsAccordingToItem;
       let contentHtml = "";
-      const allRelationRows = [];
 
       groups.forEach((group) => {
         const fields = group.fields.filter(
@@ -778,10 +785,6 @@ export default {
           const value = this.escapeHtml(
             this.scalarValueForPrint(fieldName, group),
           );
-
-          // if (this.fieldsSchema[fieldName]?.type === "link") {
-          //   allRelationRows.push(...this.relationRowsForField(fieldName));
-          // }
 
           rowsHtml += `<tr><th style="width: 15%;">${label}</th><td>${value.replace(/\n/g, "<br>")}</td></tr>`;
         });

--- a/src/services/__tests__/itemPrint.spec.js
+++ b/src/services/__tests__/itemPrint.spec.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { generateItemPrintHtml } from "@/services/itemPrint";
+
+function printOptions(overrides = {}) {
+  return {
+    selectedItem: {
+      Type: "Context",
+      Identifier: "CTX-1",
+      Title: "A <special> context",
+      Related: "uuid-10\nuuid-2",
+      Trench: "T1",
+    },
+    groups: [
+      {
+        group: "Identity",
+        labels: { en: "Identity & description" },
+        fields: [
+          { field: "Type" },
+          { field: "Title", labels: { en: "Title" } },
+          { field: "Related", link: true },
+        ],
+      },
+    ],
+    fieldsOfCurrentItem: ["Type", "Identifier", "Title", "Related", "Trench"],
+    lang: "en",
+    project: "My Project",
+    projectPreferencesTypes: [],
+    projectPreferencesTypesTranslation: {
+      Context: "Archaeological context",
+      Find: "Find",
+    },
+    projectPreferencesFields: [],
+    projectPreferencesFieldsWithTranslation: {
+      Related: "Relations",
+    },
+    fieldsSchema: {
+      Type: { type: "string" },
+      Title: { type: "string" },
+      Related: { type: "link" },
+    },
+    checkedTrenchesData: {
+      T1: [
+        {
+          IdentifierUUID: "uuid-10",
+          Type: "Find",
+          Identifier: "F10",
+          Title: "Later",
+        },
+        {
+          IdentifierUUID: "uuid-2",
+          Type: "Find",
+          Identifier: "F2",
+          Title: "Earlier",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("generateItemPrintHtml", () => {
+  it("generates the item title and escaped field content", () => {
+    const html = generateItemPrintHtml(printOptions());
+
+    expect(html).toContain(
+      "<title>My Project Archaeological context CTX-1</title>",
+    );
+    expect(html).toContain("<h2>Identity &amp; description</h2>");
+    expect(html).toContain("A &lt;special&gt; context");
+  });
+
+  it("sorts relation rows naturally by identifier", () => {
+    const html = generateItemPrintHtml(printOptions());
+
+    expect(html.indexOf("Find | F2 | Earlier")).toBeLessThan(
+      html.indexOf("Find | F10 | Later"),
+    );
+  });
+});

--- a/src/services/indexedDbManager.js
+++ b/src/services/indexedDbManager.js
@@ -1,6 +1,6 @@
 export const openDB = () => {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open("iDigIndexedDB", 1);
+    const request = indexedDB.open("iDigIndexedDB");
 
     request.onupgradeneeded = (event) => {
       const db = event.target.result;

--- a/src/services/itemPrint.js
+++ b/src/services/itemPrint.js
@@ -1,0 +1,259 @@
+import dayjs from "dayjs";
+import { resolveFieldDefinition } from "@/services/fieldDefinition";
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function fieldLabel(field, group, options) {
+  return (
+    field.labels?.[options.lang] ||
+    options.projectPreferencesFieldsWithTranslation?.[field.field] ||
+    options.fieldsSchema?.[field.field]?.labels?.[options.lang] ||
+    field.field
+  );
+}
+
+function itemTypeLabel(item, typeTranslations) {
+  if (!item) {
+    return "Unknown";
+  }
+
+  return (
+    typeTranslations[item.Subtype] ||
+    typeTranslations[item.Type] ||
+    item.Type ||
+    ""
+  );
+}
+
+function relationRows(fieldName, options) {
+  const raw = options.selectedItem[fieldName];
+  if (!raw) {
+    return [];
+  }
+
+  const uuids = String(raw)
+    .split("\n")
+    .map((uuid) => uuid.trim())
+    .filter(Boolean);
+  const trenchItems =
+    options.checkedTrenchesData?.[options.selectedItem.Trench] || [];
+
+  return uuids.map((uuid) => {
+    const item = trenchItems.find((candidate) =>
+      candidate.IdentifierUUID.includes(uuid),
+    );
+
+    return {
+      type: item
+        ? itemTypeLabel(item, options.projectPreferencesTypesTranslation)
+        : "Unknown",
+      identifier: item?.Identifier || "",
+      title: item?.Title || "",
+    };
+  });
+}
+
+function scalarValue(fieldName, group, options) {
+  const value = options.selectedItem[fieldName];
+  if (value === undefined || value === null || value === "") {
+    return "";
+  }
+
+  if (fieldName === "Type") {
+    return (
+      options.projectPreferencesTypesTranslation[
+        options.selectedItem.Subtype
+      ] ||
+      options.projectPreferencesTypesTranslation[value] ||
+      value
+    );
+  }
+
+  if (fieldName === "CoverageSerialized") {
+    return "geodata";
+  }
+
+  if (options.fieldsSchema[fieldName]?.type === "boolean") {
+    return String(value) === "1" ? "Yes" : "No";
+  }
+
+  if (options.fieldsSchema[fieldName]?.type === "DateUTC") {
+    return dayjs(value).format("DD/MM/YYYY");
+  }
+
+  const definition = resolveFieldDefinition({
+    field: fieldName,
+    groupObject: group,
+    item: options.selectedItem,
+    projectPreferencesTypes: options.projectPreferencesTypes,
+    projectPreferencesFields: options.projectPreferencesFields,
+    fieldsSchema: options.fieldsSchema,
+  });
+
+  if (
+    options.fieldsSchema[fieldName]?.type === "link" ||
+    Object.hasOwn(definition, "link")
+  ) {
+    return relationRows(fieldName, options)
+      .sort((a, b) =>
+        String(a.identifier).localeCompare(String(b.identifier), undefined, {
+          numeric: true,
+          sensitivity: "base",
+        }),
+      )
+      .map((row) =>
+        [row.type, row.identifier, row.title].filter(Boolean).join(" | "),
+      )
+      .join("\n");
+  }
+
+  return String(value);
+}
+
+export function generateItemPrintHtml(options) {
+  const sections = options.groups
+    .map((group) => {
+      const rows = group.fields
+        .filter(
+          (field) =>
+            options.fieldsOfCurrentItem.includes(field.field) &&
+            field.field !== "Subtype",
+        )
+        .map((field) => {
+          const label = escapeHtml(fieldLabel(field, group, options));
+          const value = escapeHtml(
+            scalarValue(field.field, group, options),
+          ).replace(/\n/g, "<br>");
+
+          return `<tr><th style="width: 15%;">${label}</th><td>${value}</td></tr>`;
+        })
+        .join("");
+
+      if (!rows) {
+        return "";
+      }
+
+      const groupLabel = escapeHtml(
+        group.labels ? group.labels[options.lang] : group.group,
+      );
+
+      return `
+        <section>
+          <h2>${groupLabel}</h2>
+          <table>
+            <tbody>${rows}</tbody>
+          </table>
+        </section>
+      `;
+    })
+    .join("");
+
+  const type =
+    options.projectPreferencesTypesTranslation[
+      options.selectedItem.Subtype
+    ] ||
+    options.projectPreferencesTypesTranslation[options.selectedItem.Type] ||
+    options.selectedItem.Type ||
+    "";
+  const title =
+    `${options.project} ${type} ${options.selectedItem.Identifier || ""}`.trim();
+  const escapedTitle = escapeHtml(title);
+
+  return `
+    <!doctype html>
+    <html>
+      <head>
+        <meta charset="utf-8" />
+        <title>${escapedTitle}</title>
+        <style>
+          body {
+            font-family: Arial, sans-serif;
+            color: #000;
+            background: #fff;
+            margin: 40px;
+            font-size: 12px;
+            line-height: 1.4;
+          }
+          h1 {
+            font-size: 22px;
+            margin: 0 0 12px 0;
+          }
+          h2 {
+            font-size: 14px;
+            margin: 18px 0 8px 0;
+          }
+          table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 10px;
+          }
+          th,
+          td {
+            border: 1px solid #333;
+            padding: 6px;
+            text-align: left;
+            vertical-align: top;
+          }
+          th {
+            width: 30%;
+            background: #f2f2f2;
+          }
+          @media print {
+            body {
+              margin: 40px;
+            }
+          }
+        </style>
+      </head>
+      <body>
+        <h1>${escapedTitle}</h1>
+        ${sections}
+      </body>
+    </html>
+  `;
+}
+
+export function printItemSheet(options, documentRef = document) {
+  const iframe = documentRef.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.right = "0";
+  iframe.style.bottom = "0";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  documentRef.body.appendChild(iframe);
+
+  const frameWindow = iframe.contentWindow;
+  const frameDocument = frameWindow?.document;
+  if (!frameWindow || !frameDocument) {
+    documentRef.body.removeChild(iframe);
+    return;
+  }
+
+  frameDocument.open();
+  frameDocument.write(generateItemPrintHtml(options));
+  frameDocument.close();
+
+  const runPrint = () => {
+    frameWindow.focus();
+    frameWindow.print();
+    setTimeout(() => {
+      if (documentRef.body.contains(iframe)) {
+        documentRef.body.removeChild(iframe);
+      }
+    }, 300);
+  };
+
+  if (frameDocument.readyState === "complete") {
+    runPrint();
+  } else {
+    iframe.onload = runPrint;
+  }
+}


### PR DESCRIPTION
**Issue** :  `https://github.com/esag-swiss/iDig-Webapp/issues/254`

**Description** :    
This pull request refactors and improves the item print functionality by extracting the print logic from the `TheItem.vue` component into a new, dedicated service module. It also adds automated tests for the HTML generation, ensures safer HTML escaping, and introduces natural sorting for relation rows. Additionally, there is a minor fix for the IndexedDB versioning.

### Item print logic refactor and improvements

* Extracted all item print logic from `TheItem.vue` into a new service module `itemPrint.js`, introducing `generateItemPrintHtml` and `printItemSheet` for improved maintainability and testability. This includes moving all helper functions and HTML generation out of the component. [[1]](diffhunk://#diff-7f8b199a5c558901be06005cd21dee171d4daabf8eb216266658f41de503556dR1-R259) [[2]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL647-L901)
* Improved HTML escaping for all printed fields and labels to prevent injection issues and ensure correct rendering of special characters.
* Relation rows (linked items) are now naturally sorted by their identifier in the print output, improving readability.

### Testing

* Added a new test suite for item print HTML generation in `itemPrint.spec.js`, verifying correct escaping and sorting of relation rows.

### Minor fixes

* Removed the hardcoded IndexedDB version parameter in `indexedDbManager.js` to allow for default versioning.
* Removed an unnecessary style attribute from a tooltip in `TheItem.vue`.
* Cleaned up unused imports in `TheItem.vue`. [[1]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bL341) [[2]](diffhunk://#diff-c307e02209732f5a905ce468fbeb103f88bdda6b35c4275fd15736a893707f3bR362)